### PR TITLE
[Feat] 디자인 시스템 - CategorieChip 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.1",
+        "@radix-ui/react-slot": "^1.2.3",
         "@tanstack/react-query": "^5.85.4",
         "@tanstack/react-query-devtools": "^5.85.4",
         "axios": "^1.11.0",
@@ -3452,6 +3453,39 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
+    "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.85.4",
     "@tanstack/react-query-devtools": "^5.85.4",
     "axios": "^1.11.0",

--- a/src/components/Chip/CategorieChip.stories.tsx
+++ b/src/components/Chip/CategorieChip.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj, StoryFn } from '@storybook/nextjs-vite';
+
+import { CategorieChip } from './CategorieChip';
+
+const meta: Meta<typeof CategorieChip> = {
+  title: 'Components/CategorieChip',
+  component: CategorieChip,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CategorieChip>;
+
+// Template 함수의 타입을 StoryFn으로 명시하고 args를 받도록 합니다.
+const Template: StoryFn<typeof CategorieChip> = (args) => {
+  const categories = [
+    '음악',
+    '영화/드라마',
+    '강의/책',
+    '호텔',
+    '가구/인테리어',
+    '식당',
+    '전자기기',
+    '화장품',
+    '의류/악세서리',
+    '앱',
+    '여행',
+    '테스트텍스트',
+    'test text',
+    'Test Text',
+  ];
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+      {categories.map((category) => (
+        // {...args}를 통해 variant prop이 전달됩니다.
+        <CategorieChip key={category} {...args}>
+          {category}
+        </CategorieChip>
+      ))}
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: Template,
+  args: {
+    variant: 'default',
+  },
+};
+
+export const Outline: Story = {
+  render: Template,
+  args: {
+    variant: 'outline',
+  },
+};

--- a/src/components/Chip/CategorieChip.tsx
+++ b/src/components/Chip/CategorieChip.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/cn';
+import { generateColorsFromText } from '@/utils/generateColorsFromText ';
+
+const categorieChipVariants = cva(
+  'inline-flex items-center justify-center rounded-md border px-2 py-1 caption-medium text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent text-[var(--dynamic-categorie-chip-text-color)] bg-[var(--dynamic-categorie-chip-bg-color)] [a&]:hover:bg-opacity-90',
+        outline:
+          'text-[var(--dynamic-categorie-chip-text-color)] border border-[var(--dynamic-categorie-chip-border-color)] ring ring-[var(--dynamic-categorie-chip-ring-color)] [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+const CategorieChip = ({
+  className,
+  variant,
+  asChild = false,
+  children,
+  ...props
+}: React.ComponentProps<'span'> &
+  VariantProps<typeof categorieChipVariants> & { asChild?: boolean }) => {
+  const Comp = asChild ? Slot : 'span';
+
+  const dynamicStyles = typeof children === 'string' ? generateColorsFromText(children) : {};
+
+  return (
+    <Comp
+      data-slot='badge'
+      className={cn(categorieChipVariants({ variant }), className)}
+      style={dynamicStyles}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+};
+
+export { CategorieChip, categorieChipVariants };

--- a/src/components/Chip/CategorieChip.tsx
+++ b/src/components/Chip/CategorieChip.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/cn';
 import { generateColorsFromText } from '@/utils/generateColorsFromText ';
 
 const categorieChipVariants = cva(
-  'inline-flex items-center justify-center rounded-md border px-2 py-1 caption-medium text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  'inline-flex items-center justify-center rounded-md border px-2 py-1 caption-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
   {
     variants: {
       variant: {

--- a/src/utils/generateColorsFromText .ts
+++ b/src/utils/generateColorsFromText .ts
@@ -1,0 +1,38 @@
+const simpleHash = (str: string): number => {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + (hash << 6) + (hash << 16);
+  }
+  return hash;
+};
+
+export const generateColorsFromText = (
+  text: string,
+): {
+  '--dynamic-categorie-chip-text-color': string;
+  '--dynamic-categorie-chip-bg-color': string;
+  '--dynamic-categorie-chip-border-color': string;
+  '--dynamic-categorie-chip-ring-color': string;
+} => {
+  const hash = simpleHash(text);
+  const hue = hash % 360;
+
+  // 텍스트는 밝고 채도가 높은 형광색
+  const textSaturation = 90;
+  const textLightness = 85;
+
+  // 배경은 동일한 색조(hue)를 사용하되, 살짝 어둡고 채도가 낮은 색상
+  const bgSaturation = 40;
+  const bgLightness = 15;
+  const bgAlpha = 0.8;
+
+  // 링은 text와 동일하나 투명하게
+  const ringAlpha = 0.2;
+
+  return {
+    '--dynamic-categorie-chip-text-color': `hsl(${hue}, ${textSaturation}%, ${textLightness}%)`,
+    '--dynamic-categorie-chip-bg-color': `hsla(${hue}, ${bgSaturation}%, ${bgLightness}%, ${bgAlpha})`,
+    '--dynamic-categorie-chip-border-color': `hsl(${hue}, ${textSaturation}%, ${textLightness}%)`,
+    '--dynamic-categorie-chip-ring-color': `hsla(${hue}, ${textSaturation}%, ${textLightness}%, ${ringAlpha})`,
+  };
+};


### PR DESCRIPTION
## 요약
- CategorieChip 구현
- CategorieChip Story 구현

## 세부 구현 사항
- CategorieChip은 디자인시안 2를 기준으로 구현했습니다.
- 컬러는 입력되는 텍스트를 시드로 하여 해시값을 추출한 뒤, 동적으로 컬러가 부여되게끔 구현했습니다.

## 건의사항
- prettier-plugin-tailwindcss 의존성을 설치하여 className 내부의 유틸리티 클래스들의 정렬 순서를 자동화하는 것이 좋아보입니다.

## 추가 수정 사항
- 코드 리뷰에 맞춰 브랜치 이름 변경, 기존 PR은 closed됨 #94 