### PR TITLE
[Feat] 공용 컴포넌트 Dropdown 제작

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,12 +15,9 @@ const Home = () => {
       <p className='text-body2'>body 2</p>
       <p className='text-caption'>caption</p>
 
-      <div className='flex flex-col gap-5 px-10'>
-        <h1 className='font-cafe-24-supermagic text-h1 text-primary-orange-700'>
-          {' '}
-          드롭다운 컴포넌트 예제
-        </h1>
+      <div className='flex gap-5 px-10'>
         <Dropdown items={examepleItems} placeholder='카테고리 선택' size='S'></Dropdown>
+        <Dropdown items={examepleItems} placeholder='카테고리 선택' size='L'></Dropdown>
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,26 +1,5 @@
-'use client';
-
-import Dropdown from '@/components/Dropdown/Dropdown';
-const examepleItems = ['음악', '영화/드라마', '강의/책', '호텔', '가구/인테리어'];
-
 const Home = () => {
-  return (
-    <div>
-      <h1 className='font-cafe24-supermagic text-primary-orange-700 text-h1 font-bold'>header 1</h1>
-      <h2 className='font-cafe24-supermagic text-primary-orange-300 text-h2'>header 2</h2>
-      <h3 className='font-cafe24-supermagic text-h3 font-bold'>header 3</h3>
-      <h4 className='font-cafe24-supermagic text-h4 font-bold'>header 4</h4>
-      <p className='text-sub-headline text-state-error'>sub-headline</p>
-      <p className='text-body1 font-bold text-gray-500'>body 1</p>
-      <p className='text-body2'>body 2</p>
-      <p className='text-caption'>caption</p>
-
-      <div className='flex gap-5 px-10'>
-        <Dropdown items={examepleItems} placeholder='카테고리 선택' size='S'></Dropdown>
-        <Dropdown items={examepleItems} placeholder='카테고리 선택' size='L'></Dropdown>
-      </div>
-    </div>
-  );
+  return <div></div>;
 };
 
 export default Home;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,8 @@
+'use client';
+
+import Dropdown from '@/components/Dropdown/Dropdown';
+const examepleItems = ['음악', '영화/드라마', '강의/책', '호텔', '가구/인테리어'];
+
 const Home = () => {
   return (
     <div>
@@ -9,6 +14,14 @@ const Home = () => {
       <p className='text-body1 font-bold text-gray-500'>body 1</p>
       <p className='text-body2'>body 2</p>
       <p className='text-caption'>caption</p>
+
+      <div className='flex flex-col gap-5 px-10'>
+        <h1 className='font-cafe-24-supermagic text-h1 text-primary-orange-700'>
+          {' '}
+          드롭다운 컴포넌트 예제
+        </h1>
+        <Dropdown items={examepleItems} placeholder='카테고리 선택' size='S'></Dropdown>
+      </div>
     </div>
   );
 };

--- a/src/assets/icons/DropdownIcon.svg
+++ b/src/assets/icons/DropdownIcon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 9L12 15L18 9" stroke="#2F323A" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import Dropdown from './Dropdown';
+
+const meta: Meta<typeof Dropdown> = {
+  title: 'Components/Dropdown',
+  component: Dropdown,
+  tags: ['autodocs'],
+  argTypes: {
+    items: { control: { type: 'array' }, description: '드롭다운에 표시될 아이템들의 배열입니다.' },
+    placeholder: { control: 'text', description: '선택전 표시될 기본 텍스트입니다.' },
+    size: {
+      control: 'select',
+      options: ['S', 'L', 'mq'],
+      description: '드롭다운 아이템의 크기입니다.',
+    },
+  },
+  args: {
+    items: ['음악', '영화/드라마', '강의/책', '호텔', '가구/인테리어'],
+    placeholder: '카테고리 선택',
+    size: 'S',
+  },
+};
+
+export default meta;
+
+export const S: StoryObj<typeof Dropdown> = {
+  args: {
+    size: 'S',
+  },
+};
+
+export const L: StoryObj<typeof Dropdown> = {
+  args: {
+    size: 'L',
+  },
+};
+
+export const Mq: StoryObj<typeof Dropdown> = {
+  args: {
+    size: 'mq',
+  },
+};

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
 import Dropdown from './Dropdown';
 
 const meta: Meta<typeof Dropdown> = {
@@ -6,11 +7,13 @@ const meta: Meta<typeof Dropdown> = {
   component: Dropdown,
   tags: ['autodocs'],
   argTypes: {
-    items: { control: { type: 'array' }, description: '드롭다운에 표시될 아이템들의 배열입니다.' },
-    placeholder: { control: 'text', description: '선택전 표시될 기본 텍스트입니다.' },
+    placeholder: {
+      control: 'text',
+      description: '선택전 표시될 기본 텍스트입니다.',
+    },
     size: {
       control: 'select',
-      options: ['S', 'L', 'mq'],
+      options: ['S', 'L'],
       description: '드롭다운 아이템의 크기입니다.',
     },
   },
@@ -32,11 +35,5 @@ export const S: StoryObj<typeof Dropdown> = {
 export const L: StoryObj<typeof Dropdown> = {
   args: {
     size: 'L',
-  },
-};
-
-export const Mq: StoryObj<typeof Dropdown> = {
-  args: {
-    size: 'mq',
   },
 };

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof Dropdown> = {
     },
     size: {
       control: 'select',
-      options: ['S', 'L'],
+      options: ['S', 'L', 'mq'],
       description: '드롭다운 아이템의 크기입니다.',
     },
   },

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -7,7 +7,7 @@ import DropdownItem from './DropdownItem';
 interface DropdownProps {
   items: string[];
   placeholder: string;
-  size?: 'S' | 'L';
+  size?: 'S' | 'L' | 'mq'; // 'mq' size is removed from DropdownItemProps
 }
 
 const Dropdown: React.FC<DropdownProps> = ({

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import DropdownIcon from '@/assets/icons/DropdownIcon.svg';
+import DropdownItem from './DropdownItem';
+
+interface DropdownProps {
+  items: string[];
+  placeholder: string;
+  size?: 'S' | 'L' | 'mq';
+}
+
+const Dropdown: React.FC<DropdownProps> = ({
+  items,
+  placeholder = '카테고리 선택',
+  size = 'S',
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<string | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleItemClick = (item: string) => {
+    setSelectedItem(item);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className='relative w-[550px]' ref={dropdownRef}>
+      <button
+        type='button'
+        className='rounded-x2 text-body1-medium inline-flex h-[50px] w-full items-center justify-between gap-3 border border-gray-400 bg-white py-5 pr-4 pl-6 text-gray-800'
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <span>{selectedItem || placeholder}</span>
+        <DropdownIcon
+          className={`h-6 w-6 self-center transition-transform duration-200 ${isOpen ? 'scale-y-[-1]' : ''} `}
+          aria-hidden='true'
+        />
+      </button>
+      {isOpen && (
+        <div className='rounded-x2 absolute mt-2 w-full gap-[5px] border border-gray-400 bg-white p-[10px]'>
+          <div className='' role='menu' aria-orientation='vertical'>
+            {items.map((item) => (
+              <DropdownItem
+                key={item}
+                label={item}
+                onClick={() => handleItemClick(item)}
+                size={size}
+                isSelected={selectedItem === item}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import DropdownIcon from '@/assets/icons/DropdownIcon.svg';
+import DropdownIcon from './DropdownIcon';
 import DropdownItem from './DropdownItem';
 
 interface DropdownProps {
   items: string[];
   placeholder: string;
-  size?: 'S' | 'L' | 'mq';
+  size?: 'S' | 'L';
 }
 
 const Dropdown: React.FC<DropdownProps> = ({
@@ -41,7 +41,7 @@ const Dropdown: React.FC<DropdownProps> = ({
     <div className='relative w-[550px]' ref={dropdownRef}>
       <button
         type='button'
-        className='rounded-x2 text-body1-medium inline-flex h-[50px] w-full items-center justify-between gap-3 border border-gray-400 bg-white py-5 pr-4 pl-6 text-gray-800'
+        className='rounded-x2 text-body2-medium inline-flex h-[50px] w-full items-center justify-between gap-3 border border-gray-400 bg-white py-5 pr-4 pl-6 text-gray-800'
         onClick={() => setIsOpen(!isOpen)}
       >
         <span>{selectedItem || placeholder}</span>

--- a/src/components/Dropdown/DropdownIcon.tsx
+++ b/src/components/Dropdown/DropdownIcon.tsx
@@ -1,0 +1,18 @@
+import React, { SVGProps } from 'react';
+
+const DropdownIcon: React.FC<SVGProps<SVGSVGElement>> = ({ ...props }) => {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='2.5'
+      {...props} // className, aria-hidden 등 모든 props를 전달합니다.
+    >
+      <path strokeLinecap='round' strokeLinejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5' />
+    </svg>
+  );
+};
+
+export default DropdownIcon;

--- a/src/components/Dropdown/DropdownItem.stories.tsx
+++ b/src/components/Dropdown/DropdownItem.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof DropdownItem> = {
     },
     size: {
       control: 'select',
-      options: ['S', 'L', 'mq'],
+      options: ['S', 'L'],
       description: '아이템의 크기입니다.',
     },
     isSelected: {

--- a/src/components/Dropdown/DropdownItem.stories.tsx
+++ b/src/components/Dropdown/DropdownItem.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import DropdownItem from './DropdownItem';
+
+const meta: Meta<typeof DropdownItem> = {
+  title: 'Components/DropdownItem',
+  component: DropdownItem,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: '아이템에 표시될 텍스트입니다.',
+    },
+    size: {
+      control: 'select',
+      options: ['S', 'L', 'mq'],
+      description: '아이템의 크기입니다.',
+    },
+    isSelected: {
+      control: 'boolean',
+      description: '아이템이 선택되었는지 여부입니다.',
+    },
+  },
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof DropdownItem> = {
+  args: {
+    label: '아이템',
+    isSelected: false,
+    size: 'S',
+  },
+};
+
+export const Selected: StoryObj<typeof DropdownItem> = {
+  args: {
+    label: '선택된 아이템',
+    isSelected: true,
+    size: 'S',
+  },
+};
+
+export const Large: StoryObj<typeof DropdownItem> = {
+  args: {
+    label: '아이템 S',
+    isSelected: false,
+    size: 'L',
+  },
+};

--- a/src/components/Dropdown/DropdownItem.stories.tsx
+++ b/src/components/Dropdown/DropdownItem.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof DropdownItem> = {
     },
     size: {
       control: 'select',
-      options: ['S', 'L'],
+      options: ['S', 'L', 'mq'],
       description: '아이템의 크기입니다.',
     },
     isSelected: {

--- a/src/components/Dropdown/DropdownItem.tsx
+++ b/src/components/Dropdown/DropdownItem.tsx
@@ -7,6 +7,7 @@ const dropdownItemVariants = cva('block cursor-pointer py-2.5 px-5 rounded-x1', 
     size: {
       S: 'text-body2',
       L: 'text-body1',
+      mq: 'text-body2 md:text-body1', // 'mq' size is removed from DropdownProps
     },
     isSelected: {
       true: 'bg-primary-orange-200 text-primary-orange-600',
@@ -23,6 +24,11 @@ const dropdownItemVariants = cva('block cursor-pointer py-2.5 px-5 rounded-x1', 
       size: 'L',
       isSelected: true,
       className: 'text-body1-medium',
+    },
+    {
+      size: 'mq',
+      isSelected: true,
+      className: 'text-body2-medium md:text-body1-medium',
     },
   ],
   defaultVariants: {

--- a/src/components/Dropdown/DropdownItem.tsx
+++ b/src/components/Dropdown/DropdownItem.tsx
@@ -7,13 +7,24 @@ const dropdownItemVariants = cva('block cursor-pointer py-2.5 px-5 rounded-x1', 
     size: {
       S: 'text-body2',
       L: 'text-body1',
-      mq: 'text-body2 md:text-body1',
     },
     isSelected: {
-      true: 'bg-primary-orange-200 text-primary-orange-600 text-body2-bold',
+      true: 'bg-primary-orange-200 text-primary-orange-600',
       false: 'bg-white text-gray-600 hover:bg-gray-100',
     },
   },
+  compoundVariants: [
+    {
+      size: 'S',
+      isSelected: true,
+      className: 'text-body2-medium',
+    },
+    {
+      size: 'L',
+      isSelected: true,
+      className: 'text-body1-medium',
+    },
+  ],
   defaultVariants: {
     size: 'S',
   },

--- a/src/components/Dropdown/DropdownItem.tsx
+++ b/src/components/Dropdown/DropdownItem.tsx
@@ -1,0 +1,35 @@
+import { cva, VariantProps } from 'class-variance-authority';
+import clsx from 'clsx';
+import React from 'react';
+
+const dropdownItemVariants = cva('block cursor-pointer py-2.5 px-5 rounded-x1', {
+  variants: {
+    size: {
+      S: 'text-body2',
+      L: 'text-body1',
+      mq: 'text-body2 md:text-body1',
+    },
+    isSelected: {
+      true: 'bg-primary-orange-200 text-primary-orange-600 text-body2-bold',
+      false: 'bg-white text-gray-600 hover:bg-gray-100',
+    },
+  },
+  defaultVariants: {
+    size: 'S',
+  },
+});
+
+interface DropdownItemProps extends VariantProps<typeof dropdownItemVariants> {
+  label: string;
+  onClick?: () => void;
+}
+
+const DropdownItem: React.FC<DropdownItemProps> = ({ label, onClick, size, isSelected }) => {
+  return (
+    <div className={clsx(dropdownItemVariants({ size, isSelected }))} onClick={onClick}>
+      {label}
+    </div>
+  );
+};
+
+export default DropdownItem;

--- a/src/types/svg.d.ts
+++ b/src/types/svg.d.ts
@@ -1,0 +1,7 @@
+// src/types/svg.d.ts
+
+declare module '*.svg' {
+  import React from 'react';
+  const content: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  export default content;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import { type Config } from 'tailwindcss';
 
 const config: Config = {
-  content: ['./src/**/*.{js,ts,jsx,tsx}', './styles//*.{css,scss}'],
+  content: ['./src/**/*.{js,ts,jsx,tsx}', './src/**/*.svg', './styles//*.{css,scss}'],
   theme: {
     extend: {
       colors: {
@@ -81,6 +81,11 @@ const config: Config = {
         'body1-light': ['16px', { lineHeight: 'auto', fontWeight: '300' }],
         'body2-light': ['14px', { lineHeight: 'auto', fontWeight: '300' }],
         'caption-light': ['12px', { lineHeight: 'auto', fontWeight: '300' }],
+      },
+      borderRadius: {
+        x1: '8px',
+        x2: '12px',
+        full: '9999px',
       },
     },
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/types"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 작업 내용
- 공용 컴포넌트 Dropdown 제작 및 버그 수정
- page.tsx 정리(폰트 테스트한다고 적어둔 코드들이 있어 지웠습니다!)
- borderRadius 사이즈 정의 `tailwind.config.ts` (x1, x2, full)
<img width="500" height="305" alt="스크린샷 2025-08-26 오후 5 51 56" src="https://github.com/user-attachments/assets/5795b3b4-0a97-47fb-8b9e-793c145af294" />
<img width="500" height="305" alt="스크린샷 2025-08-26 오후 5 52 04" src="https://github.com/user-attachments/assets/e08548df-cd36-4981-abcb-d0c3bc9419cd" />

### 구현 사항
- `class-variance-authority` (cva)를 사용하여 size, isSelected에 따른 스타일을 모듈화했습니다.
- `useRef`와` useEffect`를 활용하여 드롭다운 **외부 클릭 시 메뉴가 닫히는 기능**을 구현했습니다.
- SVG 파일을 React 컴포넌트로 변환하여, className과 aria-hidden 등 다양한 props를 사용할 수 있도록 타입 안전성을 확보했습니다.
- Dropdown 컴포넌트 내부에 DropdownItem 컴포넌트를 사용하여 아이템 목록을 렌더링하도록 구조화했습니다.
- 스토리북 업데이트를 통해 Dropdown과 DropdownItem의 모든 상태를 시각적으로 확인할 수 있도록 했습니다.

**DropdownItem styles**
- 사이즈는 3가지 S와 L, mq로 구성되어 있습니다. 사이즈의 차이는 fontSize말곤 없습니다.
- Dropdown버튼의 경우 사이즈는 없습니다.(안의 Item만 사이즈가 있다고 봐주시면 됩니다.)

```tsx
const examepleItems = ['음악', '영화/드라마', '강의/책', '호텔', '가구/인테리어'];

<Dropdown items={exampleItems} placeholder="카테고리 선택' size='S'></Dropdown>
```

### 버그 수정
- 기존 DropdownIcon.svg 파일이 스토리북에서 렌더링 오류를 일으켜, SVG 코드를 직접 관리하는 DropdownIcon.tsx 컴포넌트를 새로 생성했습니다.
