### PR TITLE
[Feat] TextArea 공용 컴포넌트 제작

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,6 @@
     "**/*.{json,css,scss,md,yml,yaml}": [
       "prettier --write"
     ]
-  }
+  },
+  "type": "module"
 }

--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { TextArea } from './TextArea';
+import { TextAreaSchema } from '@/lib/validations';
+import z from 'zod';
+import { Button } from '../Button/Button';
+
+const meta: Meta<typeof TextArea> = {
+  title: 'Components/TextArea',
+  component: TextArea,
+  parameters: {
+    layout: 'centered',
+    controls: {
+      exclude: ['register'], // 자동 감지된 register prop 제외
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    maxLength: {
+      control: { type: 'number' },
+      description: 'Maximum character length',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text',
+    },
+    className: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Basic TextArea story
+export const Default: Story = {
+  args: {
+    placeholder: 'Enter your text here...',
+    maxLength: 10,
+  },
+};
+
+// TextArea with form validation
+export const WithValidation: Story = {
+  render: (args) => {
+    const schema = z.object({
+      newTextArea1: TextAreaSchema(args.maxLength || 100),
+      newTextArea2: TextAreaSchema(args.maxLength || 100),
+    });
+    type SigninFormInputs = z.infer<typeof schema>;
+    const {
+      register,
+      formState: { isValid },
+    } = useForm<SigninFormInputs>({
+      resolver: zodResolver(schema),
+      mode: 'onChange',
+    });
+
+    console.log(`isValid: ${isValid}`);
+
+    return (
+      <div className='flex w-96 flex-col items-center gap-4'>
+        <TextArea {...args} register={register('newTextArea1')} />
+        <TextArea {...args} register={register('newTextArea2')} />
+        <Button disabled={!isValid} type='submit'>
+          제출
+        </Button>
+      </div>
+    );
+  },
+  args: {
+    placeholder: '값을 입력하세요',
+    maxLength: 50,
+  },
+};

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/cn';
+import { forwardRef, TextareaHTMLAttributes, useState } from 'react';
+import { UseFormRegisterReturn } from 'react-hook-form';
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  className?: string;
+  placeholder?: string;
+  register?: UseFormRegisterReturn;
+  maxLength: number;
+}
+
+export const TextArea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, placeholder, register, maxLength, ...rest }, ref) => {
+    const [currentLength, setCurrentLength] = useState(0);
+
+    const handleTextAreaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (e.target.value.length > maxLength) {
+        e.target.value = e.target.value.slice(0, maxLength);
+      }
+      setCurrentLength(e.target.value.length);
+    };
+
+    const TextAreaRegister = {
+      ...register,
+      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        handleTextAreaChange(e);
+        register?.onChange?.(e);
+      },
+    };
+
+    return (
+      <div className='flex w-full flex-col gap-2 rounded-lg border-1 border-gray-300 p-3 md:p-5'>
+        <textarea
+          ref={ref}
+          className={cn('text-body2 md:text-body1 resize-none outline-0', className)}
+          placeholder={placeholder}
+          {...TextAreaRegister}
+          {...rest}
+        />
+        <div className='text-body2 text-right text-gray-700'>{`${currentLength}/${maxLength}`}</div>
+      </div>
+    );
+  },
+);
+
+TextArea.displayName = 'TextArea';

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -37,7 +37,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           {...TextAreaRegister}
           {...rest}
         />
-        <div className='text-body2 text-right text-gray-700'>{`${currentLength}/${maxLength}`}</div>
+        <p className='text-body2 text-right text-gray-700'>{`${currentLength}/${maxLength}`}</p>
       </div>
     );
   },

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -1,0 +1,9 @@
+// lib/validations.ts
+import { z } from 'zod';
+
+export const TextAreaSchema = (maxLength: number) => {
+  return z
+    .string()
+    .min(1, '필수 입력 항목입니다') // min은 고정
+    .max(maxLength, `${maxLength}자 이하로 입력하세요`);
+};


### PR DESCRIPTION
# 📜 작업내용
공용컴포넌트 Text Area 제작

## `validations.ts`

zod schema 관리용 lib 파일입니다.
에러 메시지는 사용하지 않지만 일단 작성만 해두었습니다.
```ts
import { z } from 'zod';

export const TextAreaSchema = (maxLength: number) => {
  return z
    .string()
    .min(1, '필수 입력 항목입니다') // min은 고정
    .max(maxLength, `${maxLength}자 이하로 입력하세요`);
};
```

## `TextArea.tsx`

우선 controller를 사용하지 않고 register + useState를 사용한 이유는
모든 코드를 register로 통일 시킬 수 있도록 만들기 위해서입니다.
```tsx

    const handleTextAreaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
      if (e.target.value.length > maxLength) {
        e.target.value = e.target.value.slice(0, maxLength);
      }
      setCurrentLength(e.target.value.length);
    };

    const TextAreaRegister = {
      ...register,
      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => {
        handleTextAreaChange(e);
        register?.onChange?.(e);
      },
    };
```


아래와 같이 textarea와 p태그를 div가 감싸고, TextArea 컴포넌트를 호출할 때 전달하는 className은 textarea 태그에만 적용되는 구조입니다.
개선을 해야될 것 같기는 한데 당장은 필요없을 것 같아서 이대로 마무리 하려고 합니다.

```tsx
export const TextArea = forwardRef<HTMLTextAreaElement, TextareaProps>(
  ({ className, placeholder, register, maxLength, ...rest }, ref) => {
    return (
      <div>
        <textarea className={cn('...', className)} /> //여기에 className 적용
        <p/>
      </div>
    )
```

