### PR TITLE
[Feat] 공용 컴포넌트 Sort 제작

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,10 @@
+import Sort from '@/components/Sort/Sort';
 const Home = () => {
-  return <div></div>;
+  return (
+    <div className='flex justify-center p-10'>
+      <Sort size='mq' />
+    </div>
+  );
 };
 
 export default Home;

--- a/src/components/Sort/Sort.stories.tsx
+++ b/src/components/Sort/Sort.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import Sort from './Sort';
+
+const meta: Meta<typeof Sort> = {
+  title: 'Components/Sort',
+  component: Sort,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: {
+        type: 'radio',
+      },
+      options: ['S', 'L', 'mq'],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Sort>;
+
+export const Default: Story = {
+  args: {
+    size: 'S',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'L',
+  },
+};
+
+export const Responsive: Story = {
+  args: {
+    size: 'mq',
+  },
+};

--- a/src/components/Sort/Sort.tsx
+++ b/src/components/Sort/Sort.tsx
@@ -1,0 +1,71 @@
+'use client';
+import { cn } from '@/lib/cn';
+import { useState, useRef, useEffect } from 'react';
+import DropdownIcon from '../Dropdown/DropdownIcon';
+import SortItem from './SortItem';
+
+const sortOptions = ['최신순', '별점 높은순', '별점 낮은순', '좋아요순'];
+
+interface SortProps {
+  size: 'S' | 'L' | 'mq';
+}
+
+const Sort = ({ size = 'S' }: SortProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedItem, setSelectedItem] = useState(sortOptions[0]);
+  const sortRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (sortRef.current && !sortRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleItemClick = (option: string) => {
+    setSelectedItem(option);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className='relative w-[110px] md:w-[140px]' ref={sortRef}>
+      <button
+        type='button'
+        className='rounded-x2 text-body2 md:text-body1 inline-flex h-[42px] w-full items-center justify-between border border-gray-300 bg-white pt-3 pr-3 pb-3 pl-4 text-gray-600 md:h-13 md:pt-4 md:pr-3 md:pb-4 md:pl-4'
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <span>{selectedItem}</span>
+        <DropdownIcon
+          className={cn(
+            'h-5 w-5 self-center text-gray-500 transition-transform duration-200',
+            isOpen && 'scale-y-[-1]',
+          )}
+          aria-hidden='true'
+        />
+      </button>
+      {isOpen && (
+        <div className='rounded-x2 absolute mt-2 w-full gap-[5px] border border-gray-300 bg-white px-[6px] py-2 md:p-2'>
+          <div role='menu' aria-orientation='vertical'>
+            {sortOptions.map((option) => (
+              <SortItem
+                key={option}
+                label={option}
+                size={size}
+                isSelected={selectedItem === option}
+                onClick={() => handleItemClick(option)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Sort;

--- a/src/components/Sort/Sort.tsx
+++ b/src/components/Sort/Sort.tsx
@@ -8,6 +8,7 @@ const sortOptions = ['최신순', '별점 높은순', '별점 낮은순', '좋�
 
 interface SortProps {
   size: 'S' | 'L' | 'mq';
+  onSortChange?: (option: string) => void;
 }
 
 const Sort = ({ size = 'S' }: SortProps) => {
@@ -31,6 +32,7 @@ const Sort = ({ size = 'S' }: SortProps) => {
   const handleItemClick = (option: string) => {
     setSelectedItem(option);
     setIsOpen(false);
+    // onSortChange?.(option);
   };
 
   return (

--- a/src/components/Sort/Sort.tsx
+++ b/src/components/Sort/Sort.tsx
@@ -34,7 +34,7 @@ const Sort = ({ size = 'S' }: SortProps) => {
   };
 
   return (
-    <div className='relative w-[110px] md:w-[140px]' ref={sortRef}>
+    <div className='relative w-[115px] md:w-[140px]' ref={sortRef}>
       <button
         type='button'
         className='rounded-x2 text-body2 md:text-body1 inline-flex h-[42px] w-full items-center justify-between border border-gray-300 bg-white pt-3 pr-3 pb-3 pl-4 text-gray-600 md:h-13 md:pt-4 md:pr-3 md:pb-4 md:pl-4'

--- a/src/components/Sort/SortItem.tsx
+++ b/src/components/Sort/SortItem.tsx
@@ -1,0 +1,47 @@
+import { cva, VariantProps } from 'class-variance-authority';
+
+const sortItemVariants = cva('block cursor-pointer py-2.5 px-3 rounded-x1', {
+  variants: {
+    size: {
+      S: 'text-body2',
+      L: 'text-body1',
+      mq: 'text-body2 md:text-body1',
+    },
+    isSelected: {
+      true: 'bg-gray-900 text-white',
+      false: 'bg-white text-gray-600 hover:bg-gray-150',
+    },
+  },
+  compoundVariants: [
+    {
+      size: 'S',
+      isSelected: true,
+      className: 'text-body2-medium',
+    },
+    {
+      size: 'L',
+      isSelected: true,
+      className: 'text-body1-medium',
+    },
+    {
+      size: 'mq',
+      isSelected: true,
+      className: 'text-body2-medium md:text-body1-medium',
+    },
+  ],
+});
+
+interface SortItemProps extends VariantProps<typeof sortItemVariants> {
+  label: string;
+  onClick?: () => void;
+}
+
+const SortItem = ({ label, onClick, size, isSelected }: SortItemProps) => {
+  return (
+    <div className={sortItemVariants({ size, isSelected })} onClick={onClick}>
+      {label}
+    </div>
+  );
+};
+
+export default SortItem;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,7 @@ const config: Config = {
         },
         gray: {
           100: '#f9fafb',
+          150: '#f4f5f7',
           200: '#eff0f3',
           300: '#dbdce1',
           400: '#c4c6cc',


### PR DESCRIPTION
## 작업 내용
- 공용 컴포넌트 Sort 제작 
<img width="1134" height="570" alt="image" src="https://github.com/user-attachments/assets/4701188b-3c82-4102-955d-d59c6fe2b0ab" />

### 구현 사항
- cva를 사용해 SortItem의 스타일을 size와 isSelected prop에 따라 모듈화했습니다.
-useRef와 useEffect를 활용하여 Sort 드롭다운 외부를 클릭하면 메뉴가 닫히는 기능을 구현했습니다.
- 기존에 작성했던 DropdownIcon 컴포넌트를 재사용하고 Dropdown 컴포넌트의 코드를 재활용해 통일성을 유지했습니다.
- Sort 컴포넌트 내부에 SortItem 컴포넌트를 사용하여 아이템 목록을 렌더링하는 방식으로 구조화했습니다.
- onSortChange Prop 추가: Sort 컴포넌트가 선택된 정렬 기준을 부모 컴포넌트에 전달할 수 있도록 onSortChange prop을 추가했습니다. 이 콜백 함수를 통해 부모 컴포넌트에서 실제 데이터 정렬 로직을 실행할 수 있습니다.

**SortItem styles**
- 사이즈: S, L, mq 3가지로 구성되어 있습니다.

```tsx
  <Sort size='mq' />
```

