### PR TITLE
[Feat] 메인 페이지 초기 상품 목록 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,16 @@ import type { NextConfig } from 'next';
 import type { Configuration as WebpackConfig } from 'webpack';
 
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
   webpack(config: WebpackConfig) {
     config.module?.rules?.push({
       test: /\.svg$/,

--- a/src/api/products/getProductsAPI.ts
+++ b/src/api/products/getProductsAPI.ts
@@ -1,0 +1,22 @@
+import { baseAPI } from '@/lib/baseAPI';
+import { ProductsList } from '@/types/api';
+
+interface GetProductsParams {
+  cursor?: number;
+  order?: 'recent' | 'reviewCount' | 'rating';
+  keyword?: string;
+  category?: number;
+}
+
+export const getProductsAPI = async (params: GetProductsParams = {}): Promise<ProductsList> => {
+  const { cursor, order = 'recent', keyword, category } = params;
+
+  const queryParams = new URLSearchParams();
+  if (cursor) queryParams.append('cursor', cursor.toString());
+  queryParams.append('order', order);
+  if (keyword) queryParams.append('keyword', keyword);
+  if (category) queryParams.append('category', category.toString());
+
+  const res = await baseAPI.get(`/products?${queryParams.toString()}`);
+  return res.data;
+};

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,0 +1,251 @@
+'use client';
+import clsx from 'clsx';
+import useFilterStore from '@/store/useFilterStore';
+import ProductCard from '@/components/ProductCard/ProductCard';
+import { useState, useEffect } from 'react';
+import PaginationButton from '@/components/PaginationButton/PaginationButton';
+import { useQuery } from '@tanstack/react-query';
+import { getProductsAPI } from '@/api/products/getProductsAPI';
+import { ProductItem } from '@/types/api';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
+
+const setFilteredTitle = (
+  category: string | null,
+  query: string | null,
+  hasCategory: boolean,
+  hasKeyword: boolean,
+) => {
+  if (hasCategory && hasKeyword) {
+    return `${category}의 ${query}로 검색한 상품`;
+  } else if (hasCategory) {
+    return `${category}의 모든 상품`;
+  } else {
+    return `${query}로 검색한 상품`;
+  }
+};
+
+const HomeClient = () => {
+  const { searchQuery, selectedCategory } = useFilterStore();
+  const [currentPage, setCurrentPage] = useState(0);
+  const isDesktop = useIsDesktop();
+
+  const hasKeyword = searchQuery.trim().length > 0;
+  const hasCategory = !!selectedCategory;
+  const isFiltered = hasKeyword || hasCategory;
+  const filteredTitle = setFilteredTitle(selectedCategory, searchQuery, hasCategory, hasKeyword);
+
+  const SUBTITLE_STYLES = [
+    'font-cafe24-supermagic',
+    'text-gray-900',
+    'text-h4-bold',
+    'tracking-[0.4px]',
+  ];
+
+  const PRODUCT_IMAGE_LOADING_STYLES = ['mb-3', 'aspect-square', 'rounded-xl', 'bg-gray-200'];
+
+  const {
+    data: hotProductsData,
+    isLoading: hotProductsLoading,
+    error: hotProductsError,
+  } = useQuery({
+    queryKey: ['products', 'reviewCount'],
+    queryFn: () => getProductsAPI({ order: 'reviewCount' }),
+  });
+
+  const {
+    data: highRatingProductsData,
+    isLoading: highRatingProductsLoading,
+    error: highRatingProductsError,
+  } = useQuery({
+    queryKey: ['products', 'rating'],
+    queryFn: () => getProductsAPI({ order: 'rating' }),
+  });
+
+  const hotProducts = hotProductsData
+    ? {
+        ...hotProductsData,
+        list: hotProductsData.list.slice(0, 6),
+      }
+    : undefined;
+
+  const highRatingProducts = highRatingProductsData
+    ? {
+        ...highRatingProductsData,
+        list: highRatingProductsData.list.slice(0, 6),
+      }
+    : undefined;
+
+  // 페이지네이션 설정
+  const itemsPerPage = isDesktop ? 3 : 2;
+  const ratingProductsList = highRatingProducts?.list || [];
+  const totalPages = Math.ceil(ratingProductsList.length / itemsPerPage);
+  const startIndex = currentPage * itemsPerPage;
+  const paginatedRatingProducts = ratingProductsList.slice(startIndex, startIndex + itemsPerPage);
+
+  const nextPage = () => {
+    setCurrentPage((prev) => Math.min(prev + 1, totalPages - 1));
+  };
+
+  const prevPage = () => {
+    setCurrentPage((prev) => Math.max(prev - 1, 0));
+  };
+
+  /* isDesktop 변경 시 현재 페이지를 0으로 리셋
+   * sm, md일 떄 3페이지 -> lg일 때 3/2 로 표시되고 데이터 안 보이는 버그 있음
+   * 일단 0으로 초기화 하고 시간 남으면 추후 개선
+   */
+  useEffect(() => {
+    setCurrentPage(0);
+  }, [isDesktop]);
+
+  return (
+    <div>
+      {/* 배너 */}
+      <div
+        className={clsx(
+          'banner',
+          'bg-primary-orange-600 flex h-16 w-full items-center justify-center',
+        )}
+      >
+        <span className='font-cafe24-supermagic text-h4-bold md:text-h3-bold tracking-[0.4px] text-white'>
+          모가조아에서 지금 핫한 상품을 비교해보세요! 🚀
+        </span>
+      </div>
+      <div
+        className={clsx(
+          'mx-auto mt-8 mb-13 max-w-[1064px] px-4 md:mt-9 md:mb-15 md:px-15',
+          'content',
+        )}
+      >
+        {/* 카테고리 */}
+        <div className='category'>
+          <h4 className={clsx(...SUBTITLE_STYLES)}>카테고리</h4>
+        </div>
+
+        {/* 리뷰어 랭킹 */}
+        <div
+          className={clsx(
+            'mt-14 md:mt-16 lg:mt-14',
+            'reviewers-ranking',
+            hasCategory ? 'hidden md:block' : 'block',
+          )}
+        >
+          <h4 className={clsx(...SUBTITLE_STYLES)}>리뷰어 랭킹</h4>
+        </div>
+
+        {/* 지금 핫한 상품 */}
+        <div className={clsx('mt-14 lg:mt-15', 'hot-products', isFiltered ? 'hidden' : 'block')}>
+          <h4 className={clsx(...SUBTITLE_STYLES)}>
+            지금 핫한 상품 <span className='text-primary-orange-600'>Best</span>
+          </h4>
+          <div className='mt-5 grid grid-cols-2 gap-3 gap-y-8 md:mt-7 md:grid-cols-2 md:gap-5 md:gap-y-12 lg:grid-cols-3'>
+            {hotProductsLoading ? (
+              Array.from({ length: 6 }).map((_, index) => (
+                <div key={index} className='animate-pulse'>
+                  <div className={clsx(...PRODUCT_IMAGE_LOADING_STYLES)}></div>
+                </div>
+              ))
+            ) : hotProductsError ? (
+              <div className='col-span-full py-8 text-center'>
+                <p className='text-gray-500'>상품을 불러오는데 실패했습니다.</p>
+              </div>
+            ) : (
+              hotProducts?.list.map((item: ProductItem) => (
+                <ProductCard
+                  key={item.id}
+                  imgUrl={item.image}
+                  name={item.name}
+                  reviewCount={item.reviewCount}
+                  likeCount={item.favoriteCount}
+                  rating={item.rating}
+                />
+              ))
+            )}
+          </div>
+        </div>
+
+        <hr className='my-10 border-1 border-gray-200 md:my-12 lg:my-16'></hr>
+
+        {/* 별점이 높은 상품 */}
+        <div className={clsx('high-score-products', isFiltered ? 'hidden' : 'block')}>
+          <div className='flex items-center gap-3'>
+            <h4 className={clsx(...SUBTITLE_STYLES, 'flex-1')}>별점이 높은 상품</h4>
+            <div>
+              <span className='text-body1 text-gray-800'>
+                {totalPages > 0 ? `${currentPage + 1}` : 0}
+              </span>
+              <span className='text-body2 text-gray-500'>
+                /{totalPages > 0 ? `${totalPages}` : 0}
+              </span>
+            </div>
+            <div className='flex gap-[6px] md:hidden'>
+              <PaginationButton
+                onClick={prevPage}
+                disabled={currentPage === 0}
+                direction='prev'
+                size='sm'
+              />
+              <PaginationButton
+                onClick={nextPage}
+                disabled={currentPage === totalPages - 1}
+                direction='next'
+                size='sm'
+              />
+            </div>
+          </div>
+          <div className='mt-5 md:mt-7'>
+            <div className='relative'>
+              <PaginationButton
+                onClick={prevPage}
+                disabled={currentPage === 0}
+                direction='prev'
+                size='md'
+                className='absolute top-1/2 z-10 hidden -translate-y-1/2 md:-left-5 md:block lg:-left-14'
+              />
+              <div className='grid grid-cols-2 gap-3 gap-y-8 md:grid-cols-2 md:gap-5 md:gap-y-12 lg:grid-cols-3'>
+                {highRatingProductsLoading ? (
+                  Array.from({ length: itemsPerPage }).map((_, index) => (
+                    <div key={index} className='animate-pulse'>
+                      <div className={clsx(...PRODUCT_IMAGE_LOADING_STYLES)}></div>
+                    </div>
+                  ))
+                ) : highRatingProductsError ? (
+                  <div className='col-span-full py-8 text-center'>
+                    <p className='text-gray-500'>상품을 불러오는데 실패했습니다.</p>
+                  </div>
+                ) : (
+                  paginatedRatingProducts.map((item: ProductItem) => (
+                    <ProductCard
+                      key={item.id}
+                      imgUrl={item.image}
+                      name={item.name}
+                      reviewCount={item.reviewCount}
+                      likeCount={item.favoriteCount}
+                      rating={item.rating}
+                    />
+                  ))
+                )}
+              </div>
+              <PaginationButton
+                onClick={nextPage}
+                disabled={currentPage === totalPages - 1}
+                direction='next'
+                size='md'
+                className='absolute top-1/2 z-10 hidden -translate-y-1/2 md:-right-5 md:block lg:-right-14'
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* 필터링된 상품 */}
+        {isFiltered && (
+          <div className='filtered-products'>
+            <div className='filtered-title'>{filteredTitle}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HomeClient;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,26 @@
-const Home = () => {
-  return <div></div>;
+import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query';
+import { getProductsAPI } from '@/api/products/getProductsAPI';
+import HomeClient from './HomeClient';
+
+const Home = async () => {
+  const queryClient = new QueryClient();
+
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: ['products', 'reviewCount'],
+      queryFn: () => getProductsAPI({ order: 'reviewCount' }),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ['products', 'rating'],
+      queryFn: () => getProductsAPI({ order: 'rating' }),
+    }),
+  ]);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <HomeClient />
+    </HydrationBoundary>
+  );
 };
 
 export default Home;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,6 +2,7 @@
 import { cn } from '@/lib/cn';
 import Link from 'next/link';
 import { useState, useEffect, useRef } from 'react';
+import useFilterStore from '@/store/useFilterStore';
 import useAuthStore from '@/store/useAuthStore';
 import IconLogo from '@/assets/icons/logo.svg';
 import IconMenu from '@/assets/icons/menu.svg';
@@ -9,6 +10,7 @@ import IconSearch from '@/assets/icons/search.svg';
 
 const Header = () => {
   const { isAuthenticated } = useAuthStore();
+  const { searchQuery, setSearchQuery, clearSearchQuery } = useFilterStore();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -114,7 +116,10 @@ const Header = () => {
                   />
                 </div>
                 <button
-                  onClick={toggleSearch}
+                  onClick={() => {
+                    toggleSearch();
+                    clearSearchQuery();
+                  }}
                   className='ml-3 cursor-pointer p-2 text-xl text-gray-500 hover:text-gray-800'
                 >
                   ✕
@@ -140,6 +145,8 @@ const Header = () => {
                   type='text'
                   placeholder='상품 이름을 검색해 보세요'
                   className='bg-gray-150 text-body2 block h-full w-full rounded-full py-4 pr-4 pl-14 placeholder-gray-800 focus:border-orange-500 focus:ring-1 focus:ring-orange-500 focus:outline-none'
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
                 />
               </div>
             </div>

--- a/src/components/PaginationButton/PaginationButton.tsx
+++ b/src/components/PaginationButton/PaginationButton.tsx
@@ -1,0 +1,43 @@
+import clsx from 'clsx';
+
+export interface PaginationButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  disabled: boolean;
+  direction: 'prev' | 'next';
+  size: 'sm' | 'md';
+}
+
+const PaginationButton = ({
+  onClick,
+  disabled,
+  direction,
+  size = 'sm',
+  className,
+  ...props
+}: PaginationButtonProps) => {
+  const icon = direction === 'prev' ? '❮' : '❯';
+
+  const baseClasses =
+    'flex items-center justify-center rounded-full border-1 bg-white transition-colors';
+
+  const sizeClasses = {
+    sm: 'h-7 w-7 text-caption',
+    md: 'h-10 w-10',
+  };
+
+  const variantClasses = disabled
+    ? 'cursor-not-allowed border-gray-200 text-gray-300'
+    : 'cursor-pointer border-gray-300 text-gray-600 hover:border-gray-400 hover:text-gray-700';
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={clsx(baseClasses, sizeClasses[size], variantClasses, className)}
+      {...props}
+    >
+      {icon}
+    </button>
+  );
+};
+
+export default PaginationButton;

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -1,0 +1,56 @@
+'use client';
+import clsx from 'clsx';
+import Image from 'next/image';
+
+interface ProductCardProps {
+  imgUrl: string;
+  name: string;
+  reviewCount: number;
+  likeCount: number;
+  rating: number;
+}
+
+const PRODUCT_NAME_STYLES = [
+  'text-gray-900',
+  'text-body2-medium',
+  'tracking-[0.4px]',
+  'md:text-sub-headline-medium',
+];
+const PRODUCT_STATS_STYLES = ['text-caption', 'text-gray-700', 'tracking-[0.4px]', 'md:text-body1'];
+
+const ProductCard = ({ imgUrl, name, reviewCount, likeCount, rating }: ProductCardProps) => {
+  return (
+    <div className='flex flex-col gap-3 md:gap-5'>
+      <div className='relative aspect-square w-full md:aspect-[300/276]'>
+        <Image
+          src={imgUrl}
+          fill
+          alt={name}
+          className='rounded-xl border-1 border-gray-300'
+          style={{
+            objectFit: 'cover',
+          }}
+        />
+      </div>
+      <div className='flex flex-col gap-2 md:gap-3 md:px-2'>
+        <div className={clsx('w-full', ...PRODUCT_NAME_STYLES)}>{name}</div>
+        <div className={clsx('flex gap-2', ...PRODUCT_STATS_STYLES)}>
+          <div className='flex gap-1'>
+            <span>리뷰</span>
+            <span>{reviewCount}</span>
+          </div>
+          <div className='flex gap-1'>
+            <span>찜</span>
+            <span>{likeCount}</span>
+          </div>
+          <div className='ml-auto flex gap-1'>
+            <span>⭐</span>
+            <span>{rating}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProductCard;

--- a/src/hooks/useIsDesktop.ts
+++ b/src/hooks/useIsDesktop.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * 현재 화면이 데스크톱 크기인지 확인하는 커스텀 훅
+ * @param breakpoint - 데스크톱으로 간주할 최소 너비 (기본값: 1024px, Tailwind의 lg breakpoint)
+ * @returns isDesktop - 현재 화면이 데스크톱 크기인지 여부
+ */
+export const useIsDesktop = (breakpoint: number = 1024): boolean => {
+  const [isDesktop, setIsDesktop] = useState<boolean>(false);
+
+  useEffect(() => {
+    const checkIsDesktop = () => {
+      setIsDesktop(window.innerWidth >= breakpoint);
+    };
+
+    checkIsDesktop();
+
+    window.addEventListener('resize', checkIsDesktop);
+
+    return () => {
+      window.removeEventListener('resize', checkIsDesktop);
+    };
+  }, [breakpoint]);
+
+  return isDesktop;
+};

--- a/src/store/useFilterStore.ts
+++ b/src/store/useFilterStore.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+type Category = string | null;
+
+interface FilterStore {
+  searchQuery: string;
+  selectedCategory: Category;
+  setSearchQuery: (query: string) => void;
+  clearSearchQuery: () => void;
+  setSelectedCategory: (category: Category) => void;
+  clearSelectedCategory: () => void;
+}
+
+const useFilterStore = create<FilterStore>()(
+  devtools((set) => ({
+    searchQuery: '',
+    selectedCategory: null,
+    setSearchQuery: (query) => set({ searchQuery: query }),
+    clearSearchQuery: () => set({ searchQuery: '' }),
+    setSelectedCategory: (category) => set({ selectedCategory: category }),
+    clearSelectedCategory: () => set({ selectedCategory: null }),
+  })),
+);
+
+export default useFilterStore;


### PR DESCRIPTION
## 📜 작업내용
메인 페이지 초기 화면 지금 핫한 상품, 별점이 높은 상품 목록을 Hydration API로 프리렌더링 구현
SSR로 프리렌더링 하기 위해 UI를 클라이언트 컴포넌트로 따로 분리했습니다.(`HomeClient.tsx`)
API 로딩중일 때 회색 정사각형 반짝거림 효과를 주었습니다.

- ### 구현
테스트를 위해 API 요청에 에러를 줬습니다.

https://github.com/user-attachments/assets/adacfffb-d60e-4e3d-a8cc-b58631ef3818




- ### 이슈
    - 별점이 높은 상품 페이지네이션 
        - 모바일과 태블릿에서는 총 3페이지, 데스크탑에서는 2페이지입니다. md 이하에서 3/3 페이지인 상태에서 화면 크기를 lg로 늘리면 페이지가 3/2로 표시됩니다.
        - 우선, isDesktop 값이 바뀌면 페이지를 처음으로 리셋하는 것으로 해결(?)했습니다.
    - 페이지네이션 버튼 위치
        - 상품의 이미지의 높이 기준 중간으로 위치하고 싶은데 못 해서 일단 ProductsCard 높이 기준 중간에 위치시켰습니다.
        - 도움 필요합니다.
        
<img width="1375" height="646" alt="image" src="https://github.com/user-attachments/assets/914b724e-b398-49ae-91e8-a74240d2d1ad" />
    