### PR TITLE
[Fix] font의 lineHeight값 Figma와 브라우저간 차이로 인해 Figma 디자인 시스템 기준 고정값 설정

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -33,6 +33,7 @@ const config: Config = {
         },
         'rating-star-active': '#FFC83C',
         'state-error': '#ff0000',
+        kakao: '#FEE500',
       },
 
       fontFamily: {
@@ -42,47 +43,46 @@ const config: Config = {
 
       fontSize: {
         //Header
+        h1: ['32px', { lineHeight: '39px', fontWeight: 'normal' }],
+        'h1-bold': ['32px', { lineHeight: '39px', fontWeight: 'bold' }],
+        'h1-medium': ['32px', { lineHeight: '39px', fontWeight: '500' }],
+        'h1-light': ['32px', { lineHeight: '39px', fontWeight: '300' }],
 
-        h1: ['32px', { lineHeight: 'auto', fontWeight: 'normal' }],
-        h2: ['28px', { lineHeight: 'auto', fontWeight: 'normal' }],
-        h3: ['24px', { lineHeight: 'auto', fontWeight: 'normal' }],
-        h4: ['20px', { lineHeight: 'auto', fontWeight: 'normal' }],
+        h2: ['28px', { lineHeight: '34px', fontWeight: 'normal' }],
+        'h2-bold': ['28px', { lineHeight: '34px', fontWeight: 'bold' }],
+        'h2-medium': ['28px', { lineHeight: '34px', fontWeight: '500' }],
+        'h2-light': ['28px', { lineHeight: '34px', fontWeight: '300' }],
 
-        'h1-bold': ['32px', { lineHeight: 'auto', fontWeight: 'bold' }],
-        'h2-bold': ['28px', { lineHeight: 'auto', fontWeight: 'bold' }],
-        'h3-bold': ['24px', { lineHeight: 'auto', fontWeight: 'bold' }],
-        'h4-bold': ['20px', { lineHeight: 'auto', fontWeight: 'bold' }],
+        h3: ['24px', { lineHeight: '29px', fontWeight: 'normal' }],
+        'h3-bold': ['24px', { lineHeight: '29px', fontWeight: 'bold' }],
+        'h3-medium': ['24px', { lineHeight: '29px', fontWeight: '500' }],
+        'h3-light': ['24px', { lineHeight: '29px', fontWeight: '300' }],
 
-        'h1-medium': ['32px', { lineHeight: 'auto', fontWeight: '500' }],
-        'h2-medium': ['28px', { lineHeight: 'auto', fontWeight: '500' }],
-        'h3-medium': ['24px', { lineHeight: 'auto', fontWeight: '500' }],
-        'h4-medium': ['20px', { lineHeight: 'auto', fontWeight: '500' }],
+        h4: ['20px', { lineHeight: '24px', fontWeight: 'normal' }],
+        'h4-bold': ['20px', { lineHeight: '24px', fontWeight: 'bold' }],
+        'h4-medium': ['20px', { lineHeight: '24px', fontWeight: '500' }],
+        'h4-light': ['20px', { lineHeight: '24px', fontWeight: '300' }],
 
-        'h1-light': ['32px', { lineHeight: 'auto', fontWeight: '300' }],
-        'h2-light': ['28px', { lineHeight: 'auto', fontWeight: '300' }],
-        'h3-light': ['24px', { lineHeight: 'auto', fontWeight: '300' }],
-        'h4-light': ['20px', { lineHeight: 'auto', fontWeight: '300' }],
+        'sub-headline': ['18px', { lineHeight: '23px', fontWeight: 'normal' }],
+        'sub-headline-bold': ['18px', { lineHeight: '23px', fontWeight: 'bold' }],
+        'sub-headline-medium': ['18px', { lineHeight: '23px', fontWeight: '500' }],
+        'sub-headline-light': ['18px', { lineHeight: '23px', fontWeight: '300' }],
 
         // Body
-        'sub-headline': ['18px', { lineHeight: 'auto', fontWeight: 'normal' }],
-        body1: ['16px', { lineHeight: 'auto', fontWeight: 'normal' }],
-        body2: ['14px', { lineHeight: 'auto', fontWeight: 'normal' }],
-        caption: ['12px', { lineHeight: 'auto', fontWeight: 'normal' }],
+        body1: ['16px', { lineHeight: '20px', fontWeight: 'normal' }],
+        'body1-bold': ['16px', { lineHeight: '20px', fontWeight: 'bold' }],
+        'body1-medium': ['16px', { lineHeight: '20px', fontWeight: '500' }],
+        'body1-light': ['16px', { lineHeight: '20px', fontWeight: '300' }],
 
-        'sub-headline-bold': ['18px', { lineHeight: 'auto', fontWeight: 'bold' }],
-        'body1-bold': ['16px', { lineHeight: 'auto', fontWeight: 'bold' }],
-        'body2-bold': ['14px', { lineHeight: 'auto', fontWeight: 'bold' }],
-        'caption-bold': ['12px', { lineHeight: 'auto', fontWeight: 'bold' }],
+        body2: ['14px', { lineHeight: '18px', fontWeight: 'normal' }],
+        'body2-bold': ['14px', { lineHeight: '18px', fontWeight: 'bold' }],
+        'body2-medium': ['14px', { lineHeight: '18px', fontWeight: '500' }],
+        'body2-light': ['14px', { lineHeight: '18px', fontWeight: '300' }],
 
-        'sub-headline-medium': ['18px', { lineHeight: 'auto', fontWeight: '500' }],
-        'body1-medium': ['16px', { lineHeight: 'auto', fontWeight: '500' }],
-        'body2-medium': ['14px', { lineHeight: 'auto', fontWeight: '500' }],
-        'caption-medium': ['12px', { lineHeight: 'auto', fontWeight: '500' }],
-
-        'sub-headline-light': ['18px', { lineHeight: 'auto', fontWeight: '300' }],
-        'body1-light': ['16px', { lineHeight: 'auto', fontWeight: '300' }],
-        'body2-light': ['14px', { lineHeight: 'auto', fontWeight: '300' }],
-        'caption-light': ['12px', { lineHeight: 'auto', fontWeight: '300' }],
+        caption: ['12px', { lineHeight: '15px', fontWeight: 'normal' }],
+        'caption-bold': ['12px', { lineHeight: '15px', fontWeight: 'bold' }],
+        'caption-medium': ['12px', { lineHeight: '15px', fontWeight: '500' }],
+        'caption-light': ['12px', { lineHeight: '15px', fontWeight: '300' }],
       },
       borderRadius: {
         x1: '8px',


### PR DESCRIPTION
# 📜 작업 내용

Font의 Line Height 값이 Figma와 브라우저간 차이가 있어서
Figma 디자인 시스템의 폰트 Height 기준으로 Line Height 고정값 설정하였습니다.

ex)
### h2-bold
<img width="1317" height="568" alt="image" src="https://github.com/user-attachments/assets/f38b2d92-7e49-4fbb-a0ef-ffc2503988e0" />

- font-size: 28px
- height: 34px
- line-height: 100%

#### 실제 브라우저 적용 값
<img width="581" height="483" alt="image" src="https://github.com/user-attachments/assets/a945ad38-99a0-4018-843d-30685e82f197" />

- line-height: 42px

line-height: 100% 적용 시
<img width="564" height="459" alt="image" src="https://github.com/user-attachments/assets/93d0e32f-fa54-4cfa-8886-bc6a69449f93" />

- line-height: font-size와 동일