### PR TITLE
[Feat] 유저 프로필 화면 - 상품 영역 UI 구현, API 호출 기능 구현

### DIFF
--- a/src/api/user/getUserProductsAPI.ts
+++ b/src/api/user/getUserProductsAPI.ts
@@ -1,10 +1,12 @@
 import { baseAPI } from '@/lib/baseAPI';
 import { ProductsList } from '@/types/api';
 
+export type ProductType = keyof typeof TYPE_MAP;
+
 export interface GetUserProductsPayload {
   userId: number;
   cursor?: number;
-  type: keyof typeof TYPE_MAP;
+  type: ProductType;
 }
 
 const TYPE_MAP = {

--- a/src/app/(user)/components/ProductSection.tsx
+++ b/src/app/(user)/components/ProductSection.tsx
@@ -4,6 +4,7 @@ import OptionList from '@/components/OptionList/OptionList';
 import ProductCard from '@/components/ProductCard/ProductCard';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { getUserProductsAPI, ProductType } from '@/api/user/getUserProductsAPI';
+import clsx from 'clsx';
 
 interface Props {
   id: number;
@@ -29,10 +30,18 @@ const ProductSection = ({ id }: Props) => {
   return (
     <section className='px-4 pt-6 pb-11 md:px-15 md:pt-9 md:pb-18'>
       <div className='mx-auto max-w-235'>
-        <OptionList className='mb-8' selectedValue={productType}>
+        <OptionList className='mb-8 flex flex-row' selectedValue={productType}>
           {Object.entries(OPTION_MAP).map(([value, label]) => (
             <OptionList.button
               key={value}
+              role='tab'
+              className={clsx(
+                'text-sub-headline-medium flex items-center justify-center',
+                'h-14 w-40',
+                'cursor-pointer',
+                'data-[state=active]:border-b-3 data-[state=active]:border-gray-900 data-[state=active]:text-gray-800',
+                'data-[state=inactive]:border-b-1 data-[state=inactive]:border-gray-400 data-[state=inactive]:text-gray-400 data-[state=inactive]:hover:bg-gray-200',
+              )}
               value={value}
               onClick={() => setProductType(value as ProductType)}
             >

--- a/src/app/(user)/components/ProductSection.tsx
+++ b/src/app/(user)/components/ProductSection.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useState } from 'react';
+import { mockProductsList } from '../mock/product';
+import ProductCard from '@/components/ProductCard/ProductCard';
+import OptionList from '@/components/OptionButton/OptionList';
+
+const ProductSection = () => {
+  const [productType, setProductType] = useState('created');
+
+  const OPTION_MAP = {
+    created: '리뷰 남긴 상품',
+    reviewed: '등록한 상품',
+    favorte: '찜한 상품',
+  } as const;
+
+  return (
+    <section className='px-4 pt-6 pb-11 md:px-15 md:pt-9 md:pb-18'>
+      <OptionList className='mb-8' selectedValue={productType}>
+        {Object.entries(OPTION_MAP).map(([value, label]) => (
+          <OptionList.button key={value} value={value} onClick={() => setProductType(value)}>
+            {label}
+          </OptionList.button>
+        ))}
+      </OptionList>
+
+      <div className='mx-auto grid max-w-235 grid-cols-2 gap-x-3 gap-y-8 md:gap-x-5 md:gap-y-12 lg:grid-cols-3'>
+        {mockProductsList.list.map((product) => (
+          <ProductCard
+            key={product.id}
+            imgUrl={product.image}
+            name={product.name}
+            reviewCount={product.reviewCount}
+            likeCount={product.favoriteCount}
+            rating={product.rating}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ProductSection;

--- a/src/app/(user)/components/ProductSection.tsx
+++ b/src/app/(user)/components/ProductSection.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import { mockProductsList } from '../mock/product';
 import ProductCard from '@/components/ProductCard/ProductCard';
-import OptionList from '@/components/OptionButton/OptionList';
+import OptionList from '@/components/OptionList/OptionList';
 
 const ProductSection = () => {
   const [productType, setProductType] = useState('created');
@@ -15,14 +15,15 @@ const ProductSection = () => {
 
   return (
     <section className='px-4 pt-6 pb-11 md:px-15 md:pt-9 md:pb-18'>
-      <OptionList className='mb-8' selectedValue={productType}>
-        {Object.entries(OPTION_MAP).map(([value, label]) => (
-          <OptionList.button key={value} value={value} onClick={() => setProductType(value)}>
-            {label}
-          </OptionList.button>
-        ))}
-      </OptionList>
-
+      <div className='mx-auto max-w-235'>
+        <OptionList className='mb-8' selectedValue={productType}>
+          {Object.entries(OPTION_MAP).map(([value, label]) => (
+            <OptionList.button key={value} value={value} onClick={() => setProductType(value)}>
+              {label}
+            </OptionList.button>
+          ))}
+        </OptionList>
+      </div>
       <div className='mx-auto grid max-w-235 grid-cols-2 gap-x-3 gap-y-8 md:gap-x-5 md:gap-y-12 lg:grid-cols-3'>
         {mockProductsList.list.map((product) => (
           <ProductCard

--- a/src/app/(user)/components/ProductSection.tsx
+++ b/src/app/(user)/components/ProductSection.tsx
@@ -1,31 +1,48 @@
 'use client';
 import { useState } from 'react';
-import { mockProductsList } from '../mock/product';
-import ProductCard from '@/components/ProductCard/ProductCard';
 import OptionList from '@/components/OptionList/OptionList';
+import ProductCard from '@/components/ProductCard/ProductCard';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { getUserProductsAPI, ProductType } from '@/api/user/getUserProductsAPI';
 
-const ProductSection = () => {
-  const [productType, setProductType] = useState('created');
+interface Props {
+  id: number;
+}
 
-  const OPTION_MAP = {
+const ProductSection = ({ id }: Props) => {
+  const [productType, setProductType] = useState<ProductType>('created');
+
+  const { data: products } = useQuery({
+    queryKey: ['products', productType, id],
+    queryFn: () => getUserProductsAPI({ userId: id, type: productType }),
+    placeholderData: keepPreviousData,
+  });
+
+  const OPTION_MAP: Record<ProductType, string> = {
     created: '리뷰 남긴 상품',
     reviewed: '등록한 상품',
-    favorte: '찜한 상품',
-  } as const;
+    favorite: '찜한 상품',
+  };
+
+  if (!products) return;
 
   return (
     <section className='px-4 pt-6 pb-11 md:px-15 md:pt-9 md:pb-18'>
       <div className='mx-auto max-w-235'>
         <OptionList className='mb-8' selectedValue={productType}>
           {Object.entries(OPTION_MAP).map(([value, label]) => (
-            <OptionList.button key={value} value={value} onClick={() => setProductType(value)}>
+            <OptionList.button
+              key={value}
+              value={value}
+              onClick={() => setProductType(value as ProductType)}
+            >
               {label}
             </OptionList.button>
           ))}
         </OptionList>
       </div>
       <div className='mx-auto grid max-w-235 grid-cols-2 gap-x-3 gap-y-8 md:gap-x-5 md:gap-y-12 lg:grid-cols-3'>
-        {mockProductsList.list.map((product) => (
+        {products.list.map((product) => (
           <ProductCard
             key={product.id}
             imgUrl={product.image}

--- a/src/app/(user)/components/ProfileEditButton.tsx
+++ b/src/app/(user)/components/ProfileEditButton.tsx
@@ -1,0 +1,24 @@
+import clsx from 'clsx';
+
+interface Props {
+  onClick?: () => void;
+}
+
+const ProfileEditButton = ({ onClick }: Props) => {
+  return (
+    <button
+      className={clsx(
+        'bg-gray-150 rounded-x1 text-gray-700 hover:bg-gray-300',
+        'text-caption-medium md:text-body1-medium absolute',
+        'px-3 py-2 md:px-5 md:py-3',
+        'top-0 right-0 bottom-auto',
+        'md:top-auto md:right-7 md:bottom-0',
+      )}
+      onClick={onClick}
+    >
+      프로필 편집
+    </button>
+  );
+};
+
+export default ProfileEditButton;

--- a/src/app/(user)/components/ProfileEditButton.tsx
+++ b/src/app/(user)/components/ProfileEditButton.tsx
@@ -1,18 +1,18 @@
 import clsx from 'clsx';
+import { HTMLAttributes } from 'react';
 
-interface Props {
+interface Props extends HTMLAttributes<HTMLButtonElement> {
+  className?: string;
   onClick?: () => void;
 }
 
-const ProfileEditButton = ({ onClick }: Props) => {
+const ProfileEditButton = ({ className, onClick }: Props) => {
   return (
     <button
       className={clsx(
         'bg-gray-150 rounded-x1 text-gray-700 hover:bg-gray-300',
-        'text-caption-medium md:text-body1-medium absolute',
-        'px-3 py-2 md:px-5 md:py-3',
-        'top-0 right-0 bottom-auto',
-        'md:top-auto md:right-7 md:bottom-0',
+        'text-caption-medium md:text-body1-medium',
+        className,
       )}
       onClick={onClick}
     >

--- a/src/app/(user)/components/ProfileFollow.tsx
+++ b/src/app/(user)/components/ProfileFollow.tsx
@@ -1,0 +1,25 @@
+import { Profile } from '@/types/api';
+
+interface Props {
+  profile: Profile;
+}
+
+const ProfileFollow = ({ profile }: Props) => {
+  const ListMap = [
+    { label: '팔로우', value: profile.followeesCount },
+    { label: '팔로잉', value: profile.followersCount },
+  ];
+
+  return (
+    <div className='flex flex-row items-center gap-4 md:h-11'>
+      {ListMap.map(({ label, value }) => (
+        <div key={label} className='flex flex-row items-center gap-1'>
+          <label className='text-body1 text-gray-600'>{label}</label>
+          <p className='text-sub-headline-bold text-gray-900'>{value}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ProfileFollow;

--- a/src/app/(user)/components/ProfileImage.tsx
+++ b/src/app/(user)/components/ProfileImage.tsx
@@ -1,0 +1,15 @@
+import Image from 'next/image';
+
+interface Props {
+  imageUrl: string;
+}
+
+const ProfileImage = ({ imageUrl }: Props) => {
+  return (
+    <div className='relative aspect-square w-17 rounded-full md:w-40'>
+      <Image src={imageUrl} className='rounded-full object-cover' alt='프로필 이미지' fill />
+    </div>
+  );
+};
+
+export default ProfileImage;

--- a/src/app/(user)/components/ProfileSection.tsx
+++ b/src/app/(user)/components/ProfileSection.tsx
@@ -1,0 +1,65 @@
+'use client';
+import { Button } from '@/components/Button/Button';
+import { Profile } from '@/types/api';
+// import useAuthStore from '@/store/useAuthStore';
+import ProfileEditButton from './ProfileEditButton';
+import ProfileStats from './ProfileStats';
+import ProfileImage from './ProfileImage';
+import clsx from 'clsx';
+import ProfileFollow from './ProfileFollow';
+
+interface Props {
+  profile: Profile;
+}
+
+const ProfileSection = ({ profile }: Props) => {
+  // const { user } = useAuthStore();
+
+  // if (!user) return;
+
+  // const isMyProfile = profile.id === user.id;
+
+  const BUTTON_STYLES = 'mx-auto block w-full md:h-15 lg:w-160';
+
+  return (
+    <section className='rounded-b-4xl bg-white px-5 py-7 md:px-15 md:py-15 lg:py-10'>
+      <article className='mb-10 md:mb-12 lg:mb-10'>
+        <div className='relative mx-auto flex flex-row gap-5 md:gap-15 md:px-7 lg:max-w-170 lg:gap-16'>
+          <ProfileImage imageUrl={profile.image} />
+          <div className='flex flex-1 flex-col justify-center gap-2 md:gap-4'>
+            <p id='nickname' className='text-lg font-bold text-gray-900 md:text-2xl'>
+              {profile.nickname}
+            </p>
+            <p
+              id='description'
+              className={clsx('text-body1 hidden text-gray-900 md:inline-block', 'grow')}
+            >
+              {profile.description}
+            </p>
+            <ProfileFollow profile={profile} />
+          </div>
+          <ProfileEditButton />
+        </div>
+        <p className={clsx('text-body1 inline-block w-full text-gray-900 md:hidden', 'mx-2 mt-6')}>
+          {profile.description}
+        </p>
+      </article>
+      <ProfileStats profile={profile} />
+      {/* {isMyProfile && (
+        <Button intent='tertiary' size='S' className={BUTTON_STYLES}>
+          로그아웃
+        </Button>
+      )}
+      {!isMyProfile && (
+        <Button size='S' className={BUTTON_STYLES}>
+          팔로우
+        </Button>
+      )} */}
+      <Button intent='tertiary' size='S' className={BUTTON_STYLES}>
+        로그아웃
+      </Button>
+    </section>
+  );
+};
+
+export default ProfileSection;

--- a/src/app/(user)/components/ProfileSection.tsx
+++ b/src/app/(user)/components/ProfileSection.tsx
@@ -38,7 +38,14 @@ const ProfileSection = ({ profile }: Props) => {
             </p>
             <ProfileFollow profile={profile} />
           </div>
-          <ProfileEditButton />
+          <ProfileEditButton
+            className={clsx(
+              'absolute',
+              'px-3 py-2 md:px-5 md:py-3',
+              'top-0 right-0 bottom-auto',
+              'md:top-auto md:right-7 md:bottom-0',
+            )}
+          />
         </div>
         <p className={clsx('text-body1 inline-block w-full text-gray-900 md:hidden', 'mx-2 mt-6')}>
           {profile.description}

--- a/src/app/(user)/components/ProfileSection.tsx
+++ b/src/app/(user)/components/ProfileSection.tsx
@@ -1,24 +1,18 @@
-'use client';
 import { Button } from '@/components/Button/Button';
-import { Profile } from '@/types/api';
 // import useAuthStore from '@/store/useAuthStore';
 import ProfileEditButton from './ProfileEditButton';
 import ProfileStats from './ProfileStats';
 import ProfileImage from './ProfileImage';
 import clsx from 'clsx';
 import ProfileFollow from './ProfileFollow';
+import { Profile } from '@/types/api';
 
 interface Props {
   profile: Profile;
+  isMyProfile: boolean;
 }
 
-const ProfileSection = ({ profile }: Props) => {
-  // const { user } = useAuthStore();
-
-  // if (!user) return;
-
-  // const isMyProfile = profile.id === user.id;
-
+const ProfileSection = async ({ profile, isMyProfile }: Props) => {
   const BUTTON_STYLES = 'mx-auto block w-full md:h-15 lg:w-160';
 
   return (
@@ -52,7 +46,7 @@ const ProfileSection = ({ profile }: Props) => {
         </p>
       </article>
       <ProfileStats profile={profile} />
-      {/* {isMyProfile && (
+      {isMyProfile && (
         <Button intent='tertiary' size='S' className={BUTTON_STYLES}>
           로그아웃
         </Button>
@@ -61,10 +55,7 @@ const ProfileSection = ({ profile }: Props) => {
         <Button size='S' className={BUTTON_STYLES}>
           팔로우
         </Button>
-      )} */}
-      <Button intent='tertiary' size='S' className={BUTTON_STYLES}>
-        로그아웃
-      </Button>
+      )}
     </section>
   );
 };

--- a/src/app/(user)/components/ProfileStats.tsx
+++ b/src/app/(user)/components/ProfileStats.tsx
@@ -1,0 +1,26 @@
+import { Profile } from '@/types/api';
+
+interface Props {
+  profile: Profile;
+}
+
+const ProfileStats = ({ profile }: Props) => {
+  const ListMap = [
+    { label: '남긴 별점 리뷰', value: profile.averageRating },
+    { label: '남긴 리뷰', value: profile.reviewCount },
+    { label: '관심 카테고리', value: profile.mostFavoriteCategory?.name },
+  ];
+
+  return (
+    <article className='mx-4 mb-10 flex flex-row justify-between border-t-1 border-gray-200 pt-7 md:mx-2 md:mb-12 md:justify-around lg:mx-auto lg:mb-9 lg:max-w-170'>
+      {ListMap.map(({ label, value }) => (
+        <div key={label} className='flex flex-col items-center gap-2'>
+          <p className='text-sub-headline-bold text-black md:text-xl'>{value}</p>
+          <p className='text-body2 md:text-body1 text-gray-600'>{label}</p>
+        </div>
+      ))}
+    </article>
+  );
+};
+
+export default ProfileStats;

--- a/src/app/(user)/mock/product.tsx
+++ b/src/app/(user)/mock/product.tsx
@@ -1,0 +1,72 @@
+import { ProductsList } from '@/types/api';
+
+export const mockProductsList: ProductsList = {
+  nextCursor: 6,
+  list: [
+    {
+      updatedAt: '2025-08-30T10:15:00Z',
+      createdAt: '2025-08-20T09:00:00Z',
+      writerId: 1,
+      categoryId: 101,
+      favoriteCount: 12,
+      reviewCount: 3,
+      rating: 4.5,
+      image:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Mogazoa/user/832/1756526130023/image.png',
+      name: '무선 블루투스 이어폰',
+      id: 1,
+    },
+    {
+      updatedAt: '2025-08-29T14:30:00Z',
+      createdAt: '2025-08-18T11:20:00Z',
+      writerId: 2,
+      categoryId: 102,
+      favoriteCount: 8,
+      reviewCount: 5,
+      rating: 3.9,
+      image:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Mogazoa/user/832/1756526130023/image.png',
+      name: '휴대용 보조 배터리',
+      id: 2,
+    },
+    {
+      updatedAt: '2025-08-28T19:00:00Z',
+      createdAt: '2025-08-15T08:40:00Z',
+      writerId: 3,
+      categoryId: 103,
+      favoriteCount: 25,
+      reviewCount: 10,
+      rating: 4.8,
+      image:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Mogazoa/user/832/1756526130023/image.png',
+      name: '게이밍 키보드',
+      id: 3,
+    },
+    {
+      updatedAt: '2025-08-27T08:45:00Z',
+      createdAt: '2025-08-10T12:15:00Z',
+      writerId: 4,
+      categoryId: 104,
+      favoriteCount: 5,
+      reviewCount: 2,
+      rating: 3.2,
+      image:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Mogazoa/user/832/1756526130023/image.png',
+      name: '스마트 워치',
+      id: 4,
+    },
+    {
+      updatedAt: '2025-08-25T17:20:00Z',
+      createdAt: '2025-08-05T09:50:00Z',
+      writerId: 5,
+      categoryId: 105,
+      favoriteCount: 15,
+      reviewCount: 7,
+      rating: 4.1,
+      image:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Mogazoa/user/832/1756526130023/image.png',
+      name: '프리미엄 노트북 가방',
+      id: 5,
+    },
+  ],
+};

--- a/src/app/(user)/mock/profile.tsx
+++ b/src/app/(user)/mock/profile.tsx
@@ -1,0 +1,21 @@
+import { Profile } from '@/types/api';
+
+export const mockProfile: Profile = {
+  updatedAt: '2025-08-30T10:15:00Z',
+  createdAt: '2024-12-01T09:00:00Z',
+  teamId: '16-1-1',
+  image:
+    'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Mogazoa/user/832/1756526130023/image.png',
+  description: '프론트엔드 개발을 좋아하는 열정적인 개발자입니다.',
+  nickname: '치영',
+  id: 832,
+  mostFavoriteCategory: {
+    name: '가구/인테리어',
+    id: 101,
+  },
+  averageRating: 4.8,
+  reviewCount: 25,
+  followeesCount: 120,
+  followersCount: 98,
+  isFollowing: false,
+};

--- a/src/app/(user)/mypage/page.tsx
+++ b/src/app/(user)/mypage/page.tsx
@@ -1,12 +1,14 @@
+import { getMyProfileAPI } from '@/api/user/getMyProfileAPI';
 import ProductSection from '../components/ProductSection';
 import ProfileSection from '../components/ProfileSection';
-import { mockProfile } from '../mock/profile';
 
 const MyPage = async () => {
+  const profile = await getMyProfileAPI();
+
   return (
     <div className='bg-gray-100'>
-      <ProfileSection profile={mockProfile} />
-      <ProductSection />
+      <ProfileSection profile={profile} isMyProfile={true} />
+      <ProductSection id={profile.id} />
     </div>
   );
 };

--- a/src/app/(user)/mypage/page.tsx
+++ b/src/app/(user)/mypage/page.tsx
@@ -1,0 +1,14 @@
+import ProductSection from '../components/ProductSection';
+import ProfileSection from '../components/ProfileSection';
+import { mockProfile } from '../mock/profile';
+
+const MyPage = async () => {
+  return (
+    <div className='bg-gray-100'>
+      <ProfileSection profile={mockProfile} />
+      <ProductSection />
+    </div>
+  );
+};
+
+export default MyPage;

--- a/src/components/OptionButton/OptionList.tsx
+++ b/src/components/OptionButton/OptionList.tsx
@@ -1,0 +1,52 @@
+import clsx from 'clsx';
+import { createContext, useContext } from 'react';
+
+interface OptionContextType {
+  selectedValue?: string;
+}
+
+const OptionContext = createContext<OptionContextType>({
+  selectedValue: '',
+});
+
+interface ProviderProps {
+  children: React.ReactNode;
+  selectedValue?: string;
+  className?: string;
+}
+
+const OptionList = ({ children, selectedValue, className }: ProviderProps) => {
+  return (
+    <OptionContext.Provider value={{ selectedValue }}>
+      <div className={clsx('flex flex-row', className)}>{children}</div>
+    </OptionContext.Provider>
+  );
+};
+
+interface ButtonProps {
+  children: React.ReactNode;
+  value: string;
+  onClick: () => void;
+}
+
+const OptionButton = ({ children, value, onClick }: ButtonProps) => {
+  const { selectedValue } = useContext(OptionContext);
+  const isSelected = value === selectedValue;
+  return (
+    <button
+      className={clsx(
+        'text-sub-headline-medium flex h-14 w-40 items-center justify-center',
+        isSelected
+          ? 'border-b-3 border-gray-900 text-gray-800'
+          : 'border-b-1 border-gray-400 text-gray-400',
+      )}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+OptionList.button = OptionButton;
+
+export default OptionList;

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { createContext, useContext } from 'react';
+import { createContext, HTMLAttributes, useContext } from 'react';
 
 interface OptionContextType {
   selectedValue?: string;
@@ -18,32 +18,37 @@ interface ProviderProps {
 const OptionList = ({ children, selectedValue, className }: ProviderProps) => {
   return (
     <OptionContext.Provider value={{ selectedValue }}>
-      <div className={clsx('flex flex-row', className)}>{children}</div>
+      <div className={className}>{children}</div>
     </OptionContext.Provider>
   );
 };
 
-interface ButtonProps {
+interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
+  className?: string;
+  activeStyle?: string;
+  inactiveStyle?: string;
   value: string;
   onClick: () => void;
 }
 
-const OptionButton = ({ children, value, onClick }: ButtonProps) => {
+const OptionButton = ({
+  children,
+  className,
+  activeStyle,
+  inactiveStyle,
+  value,
+  onClick,
+  ...rest
+}: ButtonProps) => {
   const { selectedValue } = useContext(OptionContext);
   const isSelected = value === selectedValue;
   return (
     <button
-      className={clsx(
-        'text-sub-headline-medium flex items-center justify-center',
-        'h-14 w-40',
-        'cursor-pointer',
-        isSelected
-          ? 'border-b-3 border-gray-900 text-gray-800'
-          : 'border-b-1 border-gray-400 text-gray-400',
-        !isSelected && 'hover:bg-gray-200',
-      )}
+      data-state={isSelected ? 'active' : 'inactive'}
+      className={clsx(className, activeStyle, inactiveStyle)}
       onClick={onClick}
+      {...rest}
     >
       {children}
     </button>

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -35,10 +35,13 @@ const OptionButton = ({ children, value, onClick }: ButtonProps) => {
   return (
     <button
       className={clsx(
-        'text-sub-headline-medium flex h-14 w-40 items-center justify-center',
+        'text-sub-headline-medium flex items-center justify-center',
+        'h-14 w-40',
+        'cursor-pointer',
         isSelected
           ? 'border-b-3 border-gray-900 text-gray-800'
           : 'border-b-1 border-gray-400 text-gray-400',
+        !isSelected && 'hover:bg-gray-200',
       )}
       onClick={onClick}
     >

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -35,8 +35,8 @@ interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
 const OptionButton = ({
   children,
   className,
-  activeStyle,
-  inactiveStyle,
+  activeStyle = 'border-b-3 border-gray-900 text-gray-800',
+  inactiveStyle = 'border-b-1 border-gray-400 text-gray-400 hover:bg-gray-200',
   value,
   onClick,
   ...rest
@@ -46,7 +46,7 @@ const OptionButton = ({
   return (
     <button
       data-state={isSelected ? 'active' : 'inactive'}
-      className={clsx(className, activeStyle, inactiveStyle)}
+      className={clsx(className, isSelected ? activeStyle : inactiveStyle)}
       onClick={onClick}
       {...rest}
     >


### PR DESCRIPTION
# 📜 작업 내용

##  💡 `ProfileSection.tsx`

프로필 - 상품카드 영역 컴포넌트입니다.
아래는 MockData로 구현했을 때 사진입니다.
<img width="3440" height="1476" alt="image" src="https://github.com/user-attachments/assets/3b09a36d-5579-4389-b2ae-c05370b622ea" />

현재 무한 스크롤 적용 안되어있고, cursor 값 사용 없이 초기 데이터만 호출하는 기능까지만 적용하였습니다.

## 💡 `OptionList.tsx`
옵션 버튼 공용컴포넌트입니다.

> [!IMPORTANT]
> 수정 사항

Headless UI 패턴을 적용하였습니다.

스타일 지정 시 2가지 패턴을 지원합니다.

### 1. Tailwind `data-[]` 유틸리티 

OptionList의 Button은 data-state: `active` or `inactive`가 설정됩니다.
```tsx
<button
  data-state={isSelected ? 'active' : 'inactive'}
  ...
>
....
```

이를 통해 아래와 같이 선택,미선택 스타일 지정이 가능합니다.
```tsx
<OptionList.button
  key={value}
  role='tab'
  className={clsx(
    'text-sub-headline-medium flex items-center justify-center', //기본 style
    'data-[state=active]:border-b-3', //button active style
    'data-[state=inactive]:border-b-1', //button inactive style
  )}
  value={value}
  onClick={() => setProductType(value)}
>
  {label}
</OptionList.button>
```

### 2. activeStyle, inactiveStyle Props 사용
```tsx
<OptionList.button
  key={value}
  role='tab'
  className={'text-sub-headline-medium flex items-center justify-center'} //기본 style
  activeStyle='border-3' //button active style
  inactiveStyle='border-1' //button inactive style
  value={value}
  onClick={() => setProductType(value)}
>
  {label}
</OptionList.button>
```

## 💡 테스트 영상

https://github.com/user-attachments/assets/17218fa4-ce38-43d2-99fd-892bfbc734e0

