### PR TITLE
[Feat] z-index 스타일 4종 추가(globals.css)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -236,6 +236,18 @@ body {
   .layout-center {
     @apply flex flex-col items-center justify-center;
   }
+  .z-modal {
+    @apply z-[999];
+  }
+  .z-header {
+    @apply z-[99];
+  }
+  .z-header-float {
+    @apply z-[100];
+  }
+  .z-dropdown {
+    @apply z-[9];
+  }
 }
 
 /* ============================== */


### PR DESCRIPTION
# 📜 작업내용

## 💡 `globals.css`
z-index 공통 유틸리티 4종 추가

```css
@layer components {
  .z-modal {
    @apply z-[999];
  }
  .z-header {
    @apply z-[99];
  }
  .z-header-float {
    @apply z-[100];
  }
  .z-dropdown {
    @apply z-[9];
  }
}
```

## 💡 예제

```tsx
<header className={clsx('z-header sticky')}>
```
z-index만으로는 쌓임맥락을 생성하지 않기 때문에 absolute/fixed/sticky 등의 position 속성이 적용되어야 합니다.
<img width="171" height="170" alt="image" src="https://github.com/user-attachments/assets/ef78612d-0d3b-49d4-8c2b-1e71cabf51a8" />
