### PR TITLE
[Feat] 프로필페이지 - 상품 목록 무한스크롤 적용

### DIFF
--- a/src/app/(user)/components/ProductSection.tsx
+++ b/src/app/(user)/components/ProductSection.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import OptionList from '@/components/OptionList/OptionList';
 import ProductCard from '@/components/ProductCard/ProductCard';
-import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { getUserProductsAPI, ProductType } from '@/api/user/getUserProductsAPI';
 import clsx from 'clsx';
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
@@ -19,7 +19,7 @@ const ProductSection = ({ profileId }: Props) => {
     data: products,
     fetchNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery({
+  } = useSuspenseInfiniteQuery({
     queryKey: productKeys.userProductList(profileId, productType),
     queryFn: ({ pageParam }) =>
       getUserProductsAPI({
@@ -27,7 +27,6 @@ const ProductSection = ({ profileId }: Props) => {
         type: productType,
         ...(pageParam && { cursor: pageParam }),
       }),
-    placeholderData: keepPreviousData,
     initialPageParam: 0,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     // select: (data) => data.pages.flatMap((page) => page.list),
@@ -68,15 +67,14 @@ const ProductSection = ({ profileId }: Props) => {
       </div>
       <div className='mx-auto grid max-w-235 grid-cols-2 gap-x-3 gap-y-8 md:gap-x-5 md:gap-y-12 lg:grid-cols-3'>
         {allProducts.map((product) => (
-          <div key={product.id}>
-            <ProductCard
-              imgUrl={product.image}
-              name={product.name}
-              reviewCount={product.reviewCount}
-              likeCount={product.favoriteCount}
-              rating={product.rating}
-            />
-          </div>
+          <ProductCard
+            key={product.id}
+            imgUrl={product.image}
+            name={product.name}
+            reviewCount={product.reviewCount}
+            likeCount={product.favoriteCount}
+            rating={product.rating}
+          />
         ))}
         <div ref={fetchObserverRef}>{isFetchingNextPage ? '로딩 중...' : ''}</div>
       </div>

--- a/src/app/(user)/components/ProductSection.tsx
+++ b/src/app/(user)/components/ProductSection.tsx
@@ -2,30 +2,46 @@
 import { useState } from 'react';
 import OptionList from '@/components/OptionList/OptionList';
 import ProductCard from '@/components/ProductCard/ProductCard';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 import { getUserProductsAPI, ProductType } from '@/api/user/getUserProductsAPI';
 import clsx from 'clsx';
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
+import { productKeys } from '@/constant/queryKeys';
 
 interface Props {
-  id: number;
+  profileId: number;
 }
 
-const ProductSection = ({ id }: Props) => {
-  const [productType, setProductType] = useState<ProductType>('created');
+const ProductSection = ({ profileId }: Props) => {
+  const [productType, setProductType] = useState<ProductType>('reviewed');
 
-  const { data: products } = useQuery({
-    queryKey: ['products', productType, id],
-    queryFn: () => getUserProductsAPI({ userId: id, type: productType }),
+  const {
+    data: products,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: productKeys.userProductList(profileId, productType),
+    queryFn: ({ pageParam }) =>
+      getUserProductsAPI({
+        userId: profileId,
+        type: productType,
+        ...(pageParam && { cursor: pageParam }),
+      }),
     placeholderData: keepPreviousData,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    // select: (data) => data.pages.flatMap((page) => page.list),
   });
 
+  const fetchObserverRef = useIntersectionObserver(fetchNextPage);
+
   const OPTION_MAP: Record<ProductType, string> = {
-    created: '리뷰 남긴 상품',
-    reviewed: '등록한 상품',
+    reviewed: '리뷰 남긴 상품',
+    created: '등록한 상품',
     favorite: '찜한 상품',
   };
 
-  if (!products) return;
+  const allProducts = products?.pages.flatMap((page) => page.list) || [];
 
   return (
     <section className='px-4 pt-6 pb-11 md:px-15 md:pt-9 md:pb-18'>
@@ -51,16 +67,18 @@ const ProductSection = ({ id }: Props) => {
         </OptionList>
       </div>
       <div className='mx-auto grid max-w-235 grid-cols-2 gap-x-3 gap-y-8 md:gap-x-5 md:gap-y-12 lg:grid-cols-3'>
-        {products.list.map((product) => (
-          <ProductCard
-            key={product.id}
-            imgUrl={product.image}
-            name={product.name}
-            reviewCount={product.reviewCount}
-            likeCount={product.favoriteCount}
-            rating={product.rating}
-          />
+        {allProducts.map((product) => (
+          <div key={product.id}>
+            <ProductCard
+              imgUrl={product.image}
+              name={product.name}
+              reviewCount={product.reviewCount}
+              likeCount={product.favoriteCount}
+              rating={product.rating}
+            />
+          </div>
         ))}
+        <div ref={fetchObserverRef}>{isFetchingNextPage ? '로딩 중...' : ''}</div>
       </div>
     </section>
   );

--- a/src/app/(user)/mypage/page.tsx
+++ b/src/app/(user)/mypage/page.tsx
@@ -8,7 +8,7 @@ const MyPage = async () => {
   return (
     <div className='bg-gray-100'>
       <ProfileSection profile={profile} isMyProfile={true} />
-      <ProductSection id={profile.id} />
+      <ProductSection profileId={profile.id} />
     </div>
   );
 };

--- a/src/constant/queryKeys.ts
+++ b/src/constant/queryKeys.ts
@@ -2,6 +2,8 @@ export const productKeys = {
   all: ['products'] as const,
   list: () => [...productKeys.all, 'list'] as const,
   detail: (productId: number) => [...productKeys.all, productId] as const,
+  userProductList: (userId: number, type: string) =>
+    [...productKeys.all, 'user', userId, type] as const,
 };
 
 export const reviewKeys = {

--- a/src/constant/queryKeys.ts
+++ b/src/constant/queryKeys.ts
@@ -1,8 +1,10 @@
+import { ProductType } from '@/api/user/getUserProductsAPI';
+
 export const productKeys = {
   all: ['products'] as const,
   list: () => [...productKeys.all, 'list'] as const,
   detail: (productId: number) => [...productKeys.all, productId] as const,
-  userProductList: (userId: number, type: string) =>
+  userProductList: (userId: number, type: ProductType) =>
     [...productKeys.all, 'user', userId, type] as const,
 };
 


### PR DESCRIPTION
# 📜 작업내용

프로필 페이지 - 상품목록 조회 영역 무한 스크롤 적용하였습니다.

## 💡 `queryKeys.ts`

아래와 같이 userProductList로 queryKey 추가하였는데 기존 productKeys랑 합쳐야하는지 분리해야하는지 잘 모르겠네요 😅
확인해주시면 좋을 듯 합니다!
```ts
export const productKeys = {
  all: ['products'] as const,
  list: () => [...productKeys.all, 'list'] as const,
  detail: (productId: number) => [...productKeys.all, productId] as const,
  userProductList: (userId: number, type: string) =>
    [...productKeys.all, 'user', userId, type] as const,
};

```

## 💡 결과물

![Animation](https://github.com/user-attachments/assets/9aadfd85-dc78-4a3f-8f6b-b8bb01f5aa7d)
