### PR TITLE
[Feat] 상품 클릭 시 상품 상세 페이지로 이동

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -14,6 +14,7 @@ import DropdownItem from '@/components/Dropdown/DropdownItem';
 import Category from '@/app/components/Category/Category';
 import { useCategoryMap } from '@/hooks/useCategoryMap';
 import UsersRanking from '@/app/components/UsersRanking/UsersRanking';
+import BestBadge from './components/ProductCard/BestBadge';
 
 const TITLE_STYLES = 'font-cafe24-supermagic text-h4-bold tracking-[-0.4px]';
 const SUBTITLE_STYLES = `${TITLE_STYLES} text-gray-900 mb-5 md:mb-7`;
@@ -206,16 +207,22 @@ const HomeClient = () => {
                 <p className='text-gray-500'>상품을 불러오는데 실패했습니다.</p>
               </div>
             ) : (
-              hotProducts.map((item: ProductItem) => (
-                <ProductCard
-                  key={item.id}
-                  imgUrl={item.image}
-                  name={item.name}
-                  reviewCount={item.reviewCount}
-                  likeCount={item.favoriteCount}
-                  rating={item.rating}
-                  isLandingPage={true}
-                />
+              hotProducts.map((item: ProductItem, index) => (
+                <div className='relative' key={item.id}>
+                  <ProductCard
+                    id={item.id}
+                    imgUrl={item.image}
+                    name={item.name}
+                    reviewCount={item.reviewCount}
+                    likeCount={item.favoriteCount}
+                    rating={item.rating}
+                    isLandingPage={true}
+                  />
+                  <BestBadge
+                    rank={index + 1}
+                    className='absolute top-1.5 left-1.5 md:top-2.5 md:left-2.5'
+                  />
+                </div>
               ))
             )}
           </div>
@@ -225,7 +232,7 @@ const HomeClient = () => {
 
         {/* 별점이 높은 상품 */}
         <section
-          className={clsx('high-score-products', isFiltered ? 'hidden' : 'block')}
+          className={clsx('high-score-products', isFiltered ? 'hidden' : 'block', 'relative')}
           aria-label='high score products'
         >
           <div className='flex items-center gap-3'>
@@ -253,7 +260,7 @@ const HomeClient = () => {
               />
             </div>
           </div>
-          <div className='relative'>
+          <div>
             <PaginationButton
               onClick={prevPage}
               disabled={currentPage === 0}
@@ -276,6 +283,7 @@ const HomeClient = () => {
                 paginatedRatingProducts.map((item: ProductItem) => (
                   <ProductCard
                     key={item.id}
+                    id={item.id}
                     imgUrl={item.image}
                     name={item.name}
                     reviewCount={item.reviewCount}
@@ -328,6 +336,7 @@ const HomeClient = () => {
                     page.list.map((item: ProductItem) => (
                       <ProductCard
                         key={item.id}
+                        id={item.id}
                         imgUrl={item.image}
                         name={item.name}
                         reviewCount={item.reviewCount}

--- a/src/app/components/ProductCard/BestBadge.tsx
+++ b/src/app/components/ProductCard/BestBadge.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/cn';
+
+interface BestBadgeProps {
+  rank: number;
+  className?: string;
+}
+
+const BestBadge = ({ rank, className }: BestBadgeProps) => {
+  return (
+    <div
+      className={cn(
+        'rounded-x1 bg-primary-orange-500 flex h-6 w-6 items-center justify-center md:h-8 md:w-8',
+        className,
+      )}
+    >
+      <span className='text-caption-bold md:text-body1-bold text-white'>{rank}</span>
+    </div>
+  );
+};
+
+export default BestBadge;

--- a/src/app/components/ProductCard/ProductCard.tsx
+++ b/src/app/components/ProductCard/ProductCard.tsx
@@ -1,14 +1,17 @@
 'use client';
 import clsx from 'clsx';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 interface ProductCardProps {
+  id?: number;
   imgUrl: string;
   name: string;
   reviewCount: number;
   likeCount: number;
   rating: number;
   isLandingPage?: boolean;
+  linkToDetailPage?: boolean;
 }
 
 const PRODUCT_NAME_STYLES = [
@@ -25,15 +28,23 @@ const PRODUCT_STATS_STYLES = [
 ];
 
 const ProductCard = ({
+  id,
   imgUrl,
   name,
   reviewCount,
   likeCount,
   rating,
   isLandingPage = false,
+  linkToDetailPage = true,
 }: ProductCardProps) => {
+  const router = useRouter();
+  const handleClick = () => {
+    if (linkToDetailPage && id) {
+      router.push(`/product/${id}`);
+    }
+  };
   return (
-    <div className='flex flex-col gap-3 md:gap-5'>
+    <div className='flex cursor-pointer flex-col gap-3 md:gap-5' onClick={handleClick}>
       <div className='relative aspect-square w-full md:aspect-[300/276]'>
         <Image
           src={imgUrl}


### PR DESCRIPTION
## 📜 작업내용
- 상품 클릭 시 상품 상세 페이지로 이동
- 지금 핫한 상품 목록에 오렌지색 순위 스티커 표시 
- 페이지네이션 버튼 위치 수정

## 📌 참고사항
- @Chiman2937 
    치영님 프로필 페이지에서 ProductCard 컴포넌트에 id prop만 추가해주시면 됩니다.