### PR TITLE
[Feat] useIntersectionObserver 커스텀 훅에 Options 파라미터 추가(옵셔널) 외 커스텀 훅 추가 1건

### DIFF
--- a/config/imageConfig.ts
+++ b/config/imageConfig.ts
@@ -1,0 +1,27 @@
+// config/imageConfig.ts
+export const IMAGE_PATTERNS = [
+  {
+    protocol: 'https' as const,
+    hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
+    port: '',
+    pathname: '/**',
+  },
+];
+
+export const isAllowedImageUrl = (url: string): boolean => {
+  if (!url) return false;
+  if (url.startsWith('/')) return true; // public 폴더 이미지
+  if (url.startsWith('blob:')) return true; //blob 이미지
+  try {
+    const urlObj = new URL(url);
+
+    return IMAGE_PATTERNS.some((pattern) => {
+      const protocolMatch = urlObj.protocol.slice(0, -1) === pattern.protocol;
+      const hostnameMatch = urlObj.hostname === pattern.hostname;
+
+      return protocolMatch && hostnameMatch;
+    });
+  } catch {
+    return false;
+  }
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,17 +1,11 @@
 // next.config.ts
 import type { NextConfig } from 'next';
 import type { Configuration as WebpackConfig } from 'webpack';
+import { IMAGE_PATTERNS } from './config/imageConfig';
 
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
-        port: '',
-        pathname: '/**',
-      },
-    ],
+    remotePatterns: IMAGE_PATTERNS,
   },
   webpack(config: WebpackConfig) {
     config.module?.rules?.push({

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -6,17 +6,28 @@ import { useEffect, useRef } from 'react';
  * @param {() => void} callback - 요소가 뷰포트에 나타날 때 실행될 콜백.
  * @returns {React.RefObject<Element | null>} - 감지할 DOM 요소를 연결할 Ref 객체.
  */
-export const useIntersectionObserver = (callback: () => void) => {
+export const useIntersectionObserver = (
+  callback: () => void,
+  options?: {
+    root?: Element | null;
+    rootMargin?: string;
+    threshold?: number;
+  },
+) => {
   const observerRef = useRef(null);
 
   useEffect(() => {
+    if (options?.root === null && options?.root !== undefined) {
+      return;
+    }
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting) callback();
       },
       {
-        root: null, // 뷰포트를 기준으로 감지
-        threshold: 0.5, // 요소의 50%가 뷰포트에 보일 때 감지
+        root: options?.root || null, // 뷰포트를 기준으로 감지
+        threshold: options?.threshold || 0.5, // 요소의 50%가 뷰포트에 보일 때 감지
+        rootMargin: options?.rootMargin || '0px',
       },
     );
 
@@ -26,7 +37,7 @@ export const useIntersectionObserver = (callback: () => void) => {
     return () => {
       if (currentRef) observer.unobserve(currentRef);
     };
-  }, [callback]);
+  }, [callback, options]);
 
   return observerRef;
 };

--- a/src/hooks/useSafeImageUrl.ts
+++ b/src/hooks/useSafeImageUrl.ts
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useState } from 'react';
+import { isAllowedImageUrl } from '../../config/imageConfig';
+
+export const useSafeImageUrl = (imageUrl: string, fallback: string) => {
+  const getValidUrl = useCallback(
+    (url: string) => {
+      return isAllowedImageUrl(url) ? url : fallback;
+    },
+    [fallback],
+  );
+
+  const [safeImageUrl, setSafeImageUrl] = useState(() => getValidUrl(imageUrl));
+
+  const onError = () => {
+    setSafeImageUrl(fallback);
+  };
+
+  useEffect(() => {
+    setSafeImageUrl(getValidUrl(imageUrl));
+  }, [imageUrl, fallback, getValidUrl]);
+
+  return {
+    safeImageUrl,
+    onError,
+  };
+};


### PR DESCRIPTION
# 📜 작업 내용

## 💡 `useIntersectionObserver.ts`
@Heedong0924 
useIntersectionObserver 커스텀훅에 Options 파라미터를 추가하였습니다.

ViewPort 뿐만 아니라 요소의 scroll 환경에서도 무한 스크롤 구현하기 위해 적용하였습니다.
옵셔널로 추가하여 기존 코드에 영향을 주지 않습니다.

## 💡 `useSafeImageUrl.ts`

Next image 사용 시 next config에 등록되지 않은 경우 fallback 적용하기 위한 커스텀 훅입니다.

useSafeImageUrl의 커스텀훅에서 config의 패턴에 맞지 않은 Url일 경우 기본적으로 fallback Url을 반환하지만,
런타임 때 이미지 로딩 에러가 발생하는 경우도 대응하기 위해 `onError` 함수도 적용하는걸 권장드립니다.

> [!NOTE]
> 별도로 공용컴포넌트로 분리할 생각도 하긴 했는데, next image가 경우에 따라 필요한 속성이 달라지다보니 애매하게 만드는 것보다 그냥 커스텀 훅만 적용하는게 좋을 것 같아 이렇게 작업하였습니다.

사용 예시
```ts
const ProfileImageViewer = ({ imageUrl }: Props) => {
  // fallback 이미지 경로를 설정합니다.
  const defaultUrl = '/images/image_default_profile.png';
  // useSafeImageUrl에 imageUrl과 defaultUrl을 지정하면, 이를 바탕으로 사용가능한 Url (safeImageUrl)과 런타임 에러를 방지하기 위한 onError 함수를 반환합니다.
  const { safeImageUrl, onError } = useSafeImageUrl(imageUrl, defaultUrl);
  return (
    <div>
      <Image
        src={safeImageUrl}
        onError={onError}
        ...
      />
    </div>
  );
};
```

##  💡그 외
next.config.ts에 remotePatterns 에 적용하는 객체를 별도 파일로 분리하였습니다.(imageconfig.ts)