### PR TITLE
[Fix]: ImageInput 컴포넌트 이미지 추가 아이콘 사이즈 수정

### DIFF
--- a/src/components/ImageInput/ImageInput.tsx
+++ b/src/components/ImageInput/ImageInput.tsx
@@ -110,7 +110,7 @@ const ImageInput = ({ value: imageList = {}, onChange, maxImageCount }: ImageInp
         className={clsx(ADDBUTTON_STYLES, COMMON_ELEMENT_STYLES)}
         onClick={handleAddButtonClick}
       >
-        <IconAdd />
+        <IconAdd className='size-6' />
         <span>이미지추가</span>
         <div>
           <span className={clsx(Object.keys(imageList).length > 0 && 'text-primary-orange-700')}>


### PR DESCRIPTION
# 📜 작업 내용

ImageInput 이미지 추가 아이콘 사이즈를 수정하였습니다.

<img width="165" height="174" alt="image" src="https://github.com/user-attachments/assets/64ffa370-d27c-4bac-99e3-16cb0ef0aec4" />
