### PR TITLE
[Refactor] 프로필 페이지 애니메이션 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "js-cookie": "^3.0.5",
         "lodash.debounce": "^4.0.8",
         "lucide-react": "^0.541.0",
+        "motion": "^12.23.12",
         "next": "15.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -10269,6 +10270,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -12745,6 +12773,47 @@
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
       "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.12.tgz",
+      "integrity": "sha512-8jCD8uW5GD1csOoqh1WhH1A6j5APHVE15nuBkFeRiMzYBdRwyAHmSP/oXSuW0WJPZRXTFdBoG4hY9TFWNhhwng==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.23.12",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
       "license": "MIT"
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "js-cookie": "^3.0.5",
     "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.541.0",
+    "motion": "^12.23.12",
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/src/app/(user)/components/ProductSection/ProductList.tsx
+++ b/src/app/(user)/components/ProductSection/ProductList.tsx
@@ -36,6 +36,7 @@ const ProductList = ({ profileId, productType }: Props) => {
       {allProducts.map((product) => (
         <ProductCard
           key={product.id}
+          id={product.id}
           imgUrl={product.image}
           name={product.name}
           reviewCount={product.reviewCount}

--- a/src/app/(user)/components/ProductSection/ProductOptionList.tsx
+++ b/src/app/(user)/components/ProductSection/ProductOptionList.tsx
@@ -16,7 +16,11 @@ const ProductOptionList = ({ productType, onChange }: Props) => {
 
   return (
     <article className='mx-auto max-w-235'>
-      <OptionList className='mb-8 flex flex-row' selectedValue={productType}>
+      <OptionList
+        className='mb-8 flex flex-row'
+        selectedValue={productType}
+        layoutId='user-product'
+      >
         {Object.entries(OPTION_MAP).map(([value, label]) => (
           <OptionList.button
             key={value}
@@ -25,8 +29,6 @@ const ProductOptionList = ({ productType, onChange }: Props) => {
               'text-sub-headline-medium flex items-center justify-center',
               'h-14 w-40',
               'cursor-pointer',
-              'data-[state=active]:border-b-3 data-[state=active]:border-gray-900 data-[state=active]:text-gray-800',
-              'data-[state=inactive]:border-b-1 data-[state=inactive]:border-gray-400 data-[state=inactive]:text-gray-400 data-[state=inactive]:hover:bg-gray-200',
             )}
             value={value}
             onClick={() => onChange(value as ProductType)}

--- a/src/app/(user)/components/ProfileSection/components/ProfileEditButton.tsx
+++ b/src/app/(user)/components/ProfileSection/components/ProfileEditButton.tsx
@@ -91,6 +91,7 @@ const ProfileEditButton = ({ className, profile }: Props) => {
       className={clsx(
         'bg-gray-150 rounded-x1 text-gray-700 hover:bg-gray-300',
         'text-caption-medium md:text-body1-medium',
+        'hover-animate cursor-pointer',
         className,
       )}
       onClick={handleProfileEditClick}

--- a/src/app/(user)/components/ProfileSection/components/ProfileFollowInfo.tsx
+++ b/src/app/(user)/components/ProfileSection/components/ProfileFollowInfo.tsx
@@ -42,11 +42,13 @@ const ProfileFollowInfo = ({ profile }: Props) => {
       {ListMap.map(({ label, value, type }) => (
         <div
           key={label}
-          className='flex cursor-pointer flex-row items-center gap-1'
+          className='group hover-animate flex cursor-pointer flex-row items-center gap-1'
           onClick={() => handleFollowInfoClick(type)}
         >
           <label className='text-body1 cursor-pointer text-gray-600'>{label}</label>
-          <p className='text-sub-headline-bold cursor-pointer text-gray-900'>{value}</p>
+          <p className='text-sub-headline-bold group-hover:text-primary-orange-700 hover-animate cursor-pointer text-gray-900'>
+            {value}
+          </p>
         </div>
       ))}
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -279,6 +279,10 @@ body {
   .hover-grow {
     @apply transition-all duration-200 hover:scale-120;
   }
+
+  .hover-animate {
+    @apply transition-all duration-200;
+  }
 }
 
 /* Dialog Scroll bar */

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -1,23 +1,27 @@
 import clsx from 'clsx';
+import { motion } from 'motion/react';
 import { createContext, HTMLAttributes, useContext } from 'react';
 
 interface OptionContextType {
+  layoutId?: string;
   selectedValue?: string;
 }
 
 const OptionContext = createContext<OptionContextType>({
+  layoutId: '',
   selectedValue: '',
 });
 
 interface ProviderProps {
-  children: React.ReactNode;
+  layoutId?: string;
   selectedValue?: string;
   className?: string;
+  children: React.ReactNode;
 }
 
-const OptionList = ({ children, selectedValue, className }: ProviderProps) => {
+const OptionList = ({ layoutId, children, selectedValue, className }: ProviderProps) => {
   return (
-    <OptionContext.Provider value={{ selectedValue }}>
+    <OptionContext.Provider value={{ selectedValue, layoutId }}>
       <div className={className}>{children}</div>
     </OptionContext.Provider>
   );
@@ -35,22 +39,33 @@ interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
 const OptionButton = ({
   children,
   className,
-  activeStyle = 'border-b-3 border-gray-900 text-gray-800',
-  inactiveStyle = 'border-b-1 border-gray-400 text-gray-400 hover:bg-gray-200',
+  activeStyle = 'text-gray-800',
+  inactiveStyle = 'text-gray-400 hover:bg-gray-100',
   value,
   onClick,
   ...rest
 }: ButtonProps) => {
-  const { selectedValue } = useContext(OptionContext);
+  const { selectedValue, layoutId } = useContext(OptionContext);
   const isSelected = value === selectedValue;
   return (
     <button
       data-state={isSelected ? 'active' : 'inactive'}
-      className={clsx(className, isSelected ? activeStyle : inactiveStyle)}
+      className={clsx(
+        'hover-animate relative cursor-pointer',
+        className,
+        isSelected ? activeStyle : inactiveStyle,
+      )}
       onClick={onClick}
       {...rest}
     >
       {children}
+      {isSelected && (
+        <motion.div
+          layoutId={`underline-${layoutId}`}
+          className='absolute bottom-0 z-1 h-0.5 w-full bg-gray-900'
+          transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+        />
+      )}
     </button>
   );
 };


### PR DESCRIPTION
# 📜 작업내용

프로필 페이지 애니메이션을 적용하였습니다.

![Animation](https://github.com/user-attachments/assets/c8f4805c-a337-4648-9293-7021902ae4f1)

## 💡globals.css

공통 애니메이션 스타일 .hover-animate를 정의하였습니다.
```css
.hover-animate {
  @apply transition-all duration-200;
}
```
## 💡 `OptionList.tsx`

framer-motion 패키지 추가 및 underline 애니메이션을 적용하였습니다.
motion.div 의 layoutId가 동일한 요소들에 대해서 위치변경 시 애니메이션이 적용되기 때문에, 페이지별로 layoutId를 다르게 지정해줘야해서 props를 추가했습니다.

```tsx
<OptionList
  className='mb-8 flex flex-row'
  selectedValue={productType}
  layoutId='user-product'
>
...
```