### PR TITLE
[Refactor] 프로필 페이지 수정

### DIFF
--- a/src/app/(user)/components/ProductSection.tsx
+++ b/src/app/(user)/components/ProductSection.tsx
@@ -56,7 +56,7 @@ const ProductSection = ({ profileId }: Props) => {
         productType={productType}
         onChange={(value: ProductType) => setProductType(value)}
       />
-      <Suspense>
+      <Suspense fallback='로딩 중...'>
         <ProductList profileId={profileId} productType={productType} />
       </Suspense>
     </section>

--- a/src/app/(user)/components/ProductSection.tsx
+++ b/src/app/(user)/components/ProductSection.tsx
@@ -17,7 +17,6 @@ const ProductSection = ({ profileId }: Props) => {
 
   // 등록한 상품, 찜한 상품 prefetch
   useEffect(() => {
-    console.log(`run ProductSection UseEffect`);
     const prefetchProduct = async () => {
       await Promise.all([
         queryClient.prefetchInfiniteQuery({

--- a/src/app/(user)/components/ProductSection/ProductList.tsx
+++ b/src/app/(user)/components/ProductSection/ProductList.tsx
@@ -24,7 +24,6 @@ const ProductList = ({ profileId, productType }: Props) => {
       }),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-    // select: (data) => data.pages.flatMap((page) => page.list),
   });
 
   const fetchObserverRef = useIntersectionObserver(fetchNextPage);

--- a/src/app/(user)/components/ProductSection/ProductOptionList.tsx
+++ b/src/app/(user)/components/ProductSection/ProductOptionList.tsx
@@ -27,7 +27,7 @@ const ProductOptionList = ({ productType, onChange }: Props) => {
             role='tab'
             className={clsx(
               'text-sub-headline-medium flex items-center justify-center',
-              'h-14 w-40',
+              'h-14 w-40 border-b-1 border-gray-400 hover:text-gray-800',
               'cursor-pointer',
             )}
             value={value}

--- a/src/app/(user)/components/ProfileSection.tsx
+++ b/src/app/(user)/components/ProfileSection.tsx
@@ -20,7 +20,7 @@ const ProfileSection = ({ profileId, isMyProfile }: Props) => {
   if (!profile) return;
 
   return (
-    <section className='rounded-b-4xl bg-white px-5 py-7 md:px-15 md:py-15 lg:py-10'>
+    <section className='rounded-b-4xl bg-white px-5 py-7 shadow-md md:px-15 md:py-15 lg:py-10'>
       <ProfileCard profile={profile} isMyProfile={isMyProfile} />
       <ProfileStats profile={profile} />
       <ProfileButtonArea profile={profile} isMyProfile={isMyProfile} />

--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -1,0 +1,9 @@
+interface Props {
+  children: React.ReactNode;
+}
+
+const UserLayout = ({ children }: Props) => {
+  return <div className='fullscreen bg-gray-100'>{children}</div>;
+};
+
+export default UserLayout;

--- a/src/app/(user)/mypage/page.tsx
+++ b/src/app/(user)/mypage/page.tsx
@@ -3,17 +3,32 @@ import ProductSection from '../components/ProductSection';
 import { getUserInfo } from '@/lib/getUserInfo';
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 import ProfileSection from '../components/ProfileSection';
-import { profileKeys } from '@/constant/queryKeys';
+import { productKeys, profileKeys } from '@/constant/queryKeys';
+import { getUserProductsAPI } from '@/api/user/getUserProductsAPI';
 
 const MyPage = async () => {
   const queryClient = new QueryClient();
   const { userId } = await getUserInfo();
   console.log(`[DEBUG] My Profile Id: ${userId}`);
 
-  await queryClient.prefetchQuery({
-    queryKey: profileKeys.detail(userId),
-    queryFn: () => getMyProfileAPI(),
-  });
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: profileKeys.detail(userId),
+      queryFn: () => getMyProfileAPI(),
+    }),
+    queryClient.prefetchInfiniteQuery({
+      queryKey: productKeys.userProductList(userId, 'reviewed'),
+      queryFn: ({ pageParam }) =>
+        getUserProductsAPI({
+          userId: userId,
+          type: 'reviewed',
+          cursor: pageParam || 0,
+        }),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      pages: 0,
+    }),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/lib/baseAPI.ts
+++ b/src/lib/baseAPI.ts
@@ -8,10 +8,22 @@ export const baseAPI = axios.create({
 });
 
 baseAPI.interceptors.request.use(async (config) => {
-  const token = await getAccessToken();
-  if (token && config.headers) {
-    config.headers.Authorization = `Bearer ${token}`;
+  const isServer = typeof window === 'undefined';
+
+  if (isServer) {
+    const { cookies } = await import('next/headers');
+    const cookieStore = await cookies();
+    const token = cookieStore.get('accessToken')?.value;
+    if (token && config.headers) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  } else {
+    const token = await getAccessToken();
+    if (token && config.headers) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
   }
+
   return config;
 });
 

--- a/src/utils/cookieOptions.ts
+++ b/src/utils/cookieOptions.ts
@@ -3,7 +3,7 @@ export const DEFAULT_COOKIE_OPTIONS = {
   secure: process.env.NODE_ENV === 'production',
   sameSite: 'lax' as const,
   path: '/',
-  maxAge: 60 * 10,
+  maxAge: 60 * 60 * 6, //6시간
 };
 
 export const HTTPONLY_COOKIE_OPTIONS = {


### PR DESCRIPTION
#  📜작업 내용

## 💡 prefetch 로직 수정

###  ❓변경 전
프로필 페이지가 실행될 때 profile 정보만 prefetch, 상품은 클라이언트 에서 fetch 진행

###  ✔️변경 후
프로필 페이지가 실행 될 때 profile 정보와 리뷰남긴 상품 prefetch,
클라이언트에서(ProductSection이 Mount 될 때) 등록한 상품, 찜한 상품 prefetch

## 💡 `baseAPI.ts`

isServer에 의한 로직 분기를 안하고 항상 서버 액션을 통해 token을 받아오면 런타임 에러가 발생하여 분기 내용 원복하였습니다.
```
on-recoverable-error.js:40 Uncaught Error: Switched to client rendering because the server rendering errored: Server Functions cannot be called during initial render. This would create a fetch waterfall. Try to use a Server Component to pass data to Client Components instead.
```

## 💡 `cookieOptions.ts`

유효 시간을 6시간으로 수정하였습니다.