### PR TITLE
[Feat] ProductDetailPage Suspense 추가 & 중간 점검 내용 일부 반영

### DIFF
--- a/src/app/product/[productId]/ProductDetailPage.tsx
+++ b/src/app/product/[productId]/ProductDetailPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import ProductStatisticCard from './components/ProductStatisticCard';
 import ProductReviewList from './components/ProductReviewList';
 import ProductDetailHeader from './components/ProductDetailHeader';
@@ -115,14 +115,16 @@ const ProductDetailPage = ({ productId, order: initialOrder }: ProductDetailPage
               {/* <ProductEditButton className='absolute right-[-4px] bottom-[-30px] lg:right-[-30px]' /> */}
               {reviewList.length > 0 ? (
                 <>
-                  <ProductReviewList
-                    reviewList={reviewList}
-                    productId={productId}
-                    order={order}
-                    categoryName={product.category.name}
-                    productName={product.name}
-                    productImageUrl={product.image}
-                  />
+                  <Suspense fallback=''>
+                    <ProductReviewList
+                      reviewList={reviewList}
+                      productId={productId}
+                      order={order}
+                      categoryName={product.category.name}
+                      productName={product.name}
+                      productImageUrl={product.image}
+                    />
+                  </Suspense>
                   {/* Intersection Observer  */}
                   <div className='h-10 w-full' ref={observerRef} />
                 </>

--- a/src/app/product/[productId]/ProductDetailPage.tsx
+++ b/src/app/product/[productId]/ProductDetailPage.tsx
@@ -6,17 +6,15 @@ import ProductReviewList from './components/ProductReviewList';
 import ProductDetailHeader from './components/ProductDetailHeader';
 import { OrderOptions } from '@/types/api';
 import ProductEditButton from './components/ProductEditButton';
-import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 import ProductImage from './components/ProductImage';
 import ProductInfo from './components/ProductInfo';
 import ProductShareBtns from './components/ProductShareBtns';
 import ProductBtns from './components/ProductBtns';
 import { cn } from '@/lib/cn';
 import { useProductData } from './hooks/useProductData';
-import { useProductReviewListData } from './hooks/useProductReviewListData';
-import ProductNoReview from './components/ProductNoReview';
 import Dropdown from '@/components/Dropdown/Dropdown';
 import DropdownItem from '@/components/Dropdown/DropdownItem';
+import { ThreeDotsIndicator } from '@/components/ThreeDotIndicator/ThreeDotIndicator';
 
 interface ProductDetailPageProps {
   productId: number;
@@ -26,14 +24,6 @@ interface ProductDetailPageProps {
 const ProductDetailPage = ({ productId, order: initialOrder }: ProductDetailPageProps) => {
   const [order, setOrder] = useState<OrderOptions>(initialOrder);
   const { data: product } = useProductData(productId);
-  const {
-    data: reviewList,
-    hasNextPage,
-    fetchNextPage,
-  } = useProductReviewListData(productId, order);
-  const observerRef = useIntersectionObserver(() => {
-    if (hasNextPage) fetchNextPage();
-  });
 
   const pageContainerStyles = 'lg:mx-auto lg:w-full lg:max-w-[980px]';
 
@@ -112,25 +102,15 @@ const ProductDetailPage = ({ productId, order: initialOrder }: ProductDetailPage
               </Dropdown>
             </ProductDetailHeader>
             <div className='relative mb-4 lg:mb-16'>
-              {/* <ProductEditButton className='absolute right-[-4px] bottom-[-30px] lg:right-[-30px]' /> */}
-              {reviewList.length > 0 ? (
-                <>
-                  <Suspense fallback=''>
-                    <ProductReviewList
-                      reviewList={reviewList}
-                      productId={productId}
-                      order={order}
-                      categoryName={product.category.name}
-                      productName={product.name}
-                      productImageUrl={product.image}
-                    />
-                  </Suspense>
-                  {/* Intersection Observer  */}
-                  <div className='h-10 w-full' ref={observerRef} />
-                </>
-              ) : (
-                <ProductNoReview className='h-[320px] w-full' />
-              )}
+              <Suspense fallback={<ThreeDotsIndicator />}>
+                <ProductReviewList
+                  productId={productId}
+                  order={order}
+                  categoryName={product.category.name}
+                  productName={product.name}
+                  productImageUrl={product.image}
+                />
+              </Suspense>
             </div>
           </section>
         </article>

--- a/src/app/product/[productId]/ProductDetailPage.tsx
+++ b/src/app/product/[productId]/ProductDetailPage.tsx
@@ -39,7 +39,7 @@ const ProductDetailPage = ({ productId, order: initialOrder }: ProductDetailPage
           )}
         >
           {/* 상품 이미지 컨테이너 */}
-          <ProductImage className='my-5 md:my-0 lg:flex-1 lg:self-end' imageUrl={product.image} />
+          <ProductImage className='my-5 lg:flex-1 lg:self-end' imageUrl={product.image} />
           {/* 상품 설명 컨테이너 */}
           <section className='relative w-full px-5 py-8 md:px-16 md:py-12 lg:basis-51/100 lg:self-end lg:p-0'>
             <ProductEditButton className='absolute top-[-48px] right-5 md:top-[-32px] md:right-13 lg:top-[-32px] lg:right-0' />

--- a/src/app/product/[productId]/components/ProductImage.tsx
+++ b/src/app/product/[productId]/components/ProductImage.tsx
@@ -17,7 +17,7 @@ const ProductImage = ({ className, imageUrl, ...props }: ProductImageProps) => {
         {...props}
       >
         <Image
-          className='absolute inset-0 opacity-80 blur-3xl md:blur-2xl lg:blur-xl'
+          className='absolute inset-0 opacity-80 blur-3xl md:opacity-50 md:blur-2xl lg:opacity-80 lg:blur-xl'
           src={imageUrl}
           alt='블러 이미지'
           fill

--- a/src/app/product/[productId]/components/ProductReviewCard.tsx
+++ b/src/app/product/[productId]/components/ProductReviewCard.tsx
@@ -2,7 +2,7 @@ import ThumbsUpLikes from '@/components/Likes/ThumbsUpLikes';
 import Rating from '@/components/Rating/Rating';
 import { OrderOptions, Review } from '@/types/api';
 import Image from 'next/image';
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes, useState } from 'react';
 import { formatDate } from '@/utils/formatDate';
 import { cn } from '@/lib/cn';
 import clsx from 'clsx';
@@ -10,6 +10,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { removeReview } from '@/api/review/removeReview';
 import { productKeys, reviewKeys } from '@/constant/queryKeys';
 import useDialog from '@/hooks/useDialog';
+import Link from 'next/link';
 
 interface ProductReviewCardProps extends HTMLAttributes<HTMLDivElement> {
   productId: number;
@@ -41,6 +42,8 @@ const ProductReviewCard = ({
 
   const { open } = useDialog();
 
+  const [isDeleteMode, setIsDeleteMode] = useState(false);
+
   const reviewInfoTextStyle = 'text-gray-600 text-caption md:text-body2';
   const editTextStyle = 'cursor-pointer underline underline-offset-2';
 
@@ -55,42 +58,79 @@ const ProductReviewCard = ({
     >
       {/* 별점, 사용자명, 편집 버튼, 날짜 등 헤더 */}
       <div className='flex-between-center w-full gap-2'>
-        {/*  */}
+        {/* 별점 */}
         <Rating rating={review.rating} readonly size='sm' />
-        <span className={clsx(reviewInfoTextStyle, 'grow-1')}>{review.user.nickname}</span>
-        <button
-          className={clsx(reviewInfoTextStyle, editTextStyle)}
-          onClick={() =>
-            open({
-              dialogName: 'review-form-dialog',
-              dialogProps: {
-                mode: 'edit',
-                order,
-                productId,
-                categoryName,
-                productName,
-                productImageUrl,
-                reviewId: review.id,
-                rating: review.rating,
-                reviewContent: review.content,
-                reviewImages: review.reviewImages,
-              },
-              isBlockBackgroundClose: true,
-            })
-          }
-        >
-          수정
-        </button>
-        <button
-          className={clsx(reviewInfoTextStyle, editTextStyle)}
-          onClick={() => {
-            reviewRemoveMutate(review.id);
-          }}
-        >
-          삭제
-        </button>
+        {/* 사용자명 */}
+        <span className={clsx(reviewInfoTextStyle, 'grow-1')}>
+          <Link
+            href={{
+              pathname: `/user/${review.userId}`,
+            }}
+          >
+            {review.user.nickname}
+          </Link>
+        </span>
+
+        {/* 리뷰 수정 삭제 버튼 */}
+        {isDeleteMode ? (
+          <div className='flex gap-2'>
+            <span className={clsx(reviewInfoTextStyle, 'text-primary-orange-500 font-semibold')}>
+              리뷰를 삭제할까요?
+            </span>
+            <button
+              className={clsx(reviewInfoTextStyle, editTextStyle)}
+              onClick={() => {
+                reviewRemoveMutate(review.id);
+              }}
+            >
+              예
+            </button>
+            <button
+              className={clsx(reviewInfoTextStyle, editTextStyle)}
+              onClick={() => setIsDeleteMode(false)}
+            >
+              아니요
+            </button>
+          </div>
+        ) : (
+          <div className='flex gap-2'>
+            <button
+              className={clsx(reviewInfoTextStyle, editTextStyle)}
+              onClick={() =>
+                open({
+                  dialogName: 'review-form-dialog',
+                  dialogProps: {
+                    mode: 'edit',
+                    order,
+                    productId,
+                    categoryName,
+                    productName,
+                    productImageUrl,
+                    reviewId: review.id,
+                    rating: review.rating,
+                    reviewContent: review.content,
+                    reviewImages: review.reviewImages,
+                  },
+                  isBlockBackgroundClose: true,
+                })
+              }
+            >
+              수정
+            </button>
+            <button
+              className={clsx(reviewInfoTextStyle, editTextStyle)}
+              onClick={() => {
+                setIsDeleteMode(true);
+              }}
+            >
+              삭제
+            </button>
+          </div>
+        )}
+
+        {/* 작성날짜 */}
         <span className={clsx(reviewInfoTextStyle, 'text-gray-700')}>
-          {formatDate(review.updatedAt)}
+          {formatDate(review.createdAt)}
         </span>
       </div>
       {/* 본문 */}

--- a/src/app/product/[productId]/components/ProductReviewList.tsx
+++ b/src/app/product/[productId]/components/ProductReviewList.tsx
@@ -1,10 +1,12 @@
 import { HTMLAttributes } from 'react';
 import ProductReviewCard from './ProductReviewCard';
-import { OrderOptions, Review } from '@/types/api';
+import { OrderOptions } from '@/types/api';
 import { cn } from '@/lib/cn';
+import { useProductReviewListData } from '../hooks/useProductReviewListData';
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
+import ProductNoReview from './ProductNoReview';
 
 interface ProductReviewListProps extends HTMLAttributes<HTMLDivElement> {
-  reviewList: Review[];
   productId: number;
   order: OrderOptions;
   categoryName: string;
@@ -14,7 +16,6 @@ interface ProductReviewListProps extends HTMLAttributes<HTMLDivElement> {
 
 const ProductReviewList = ({
   className,
-  reviewList,
   productId,
   order,
   categoryName,
@@ -22,7 +23,16 @@ const ProductReviewList = ({
   productImageUrl,
   ...props
 }: ProductReviewListProps) => {
-  return (
+  const {
+    data: reviewList,
+    hasNextPage,
+    fetchNextPage,
+  } = useProductReviewListData(productId, order);
+  const observerRef = useIntersectionObserver(() => {
+    if (hasNextPage) fetchNextPage();
+  });
+
+  return reviewList.length > 0 ? (
     <div className={cn('flex-between-center flex-col gap-5', className)} {...props}>
       {reviewList.map((review) => (
         <ProductReviewCard
@@ -35,7 +45,11 @@ const ProductReviewList = ({
           review={review}
         />
       ))}
+      {/* Intersection Observer  */}
+      <div className='h-10 w-full' ref={observerRef} />
     </div>
+  ) : (
+    <ProductNoReview className='h-[320px] w-full' />
   );
 };
 

--- a/src/app/product/[productId]/components/ProductShareBtns.tsx
+++ b/src/app/product/[productId]/components/ProductShareBtns.tsx
@@ -3,6 +3,7 @@ import { HTMLAttributes } from 'react';
 import KakaoShareBtn from '@/assets/icons/icon_kakao_share.svg';
 import ShareBtn from '@/assets/icons/icon_share.svg';
 import { cn } from '@/lib/cn';
+import useCopyToClipboard from '@/hooks/useCopyToClipboard';
 
 interface ProductShareBtnsProps extends HTMLAttributes<HTMLDivElement> {
   productId: number;
@@ -15,11 +16,13 @@ const ProductShareBtns = ({
   isHeartFavorite,
   ...props
 }: ProductShareBtnsProps) => {
+  const [_isCopyed, copy] = useCopyToClipboard();
+
   return (
     <div className={cn('inline-flex-between-center mb-8 gap-3 md:mb-12', className)} {...props}>
       <HeartLikes productId={productId} favorite={isHeartFavorite} />
       <KakaoShareBtn className='hover-grow cursor-pointer' />
-      <ShareBtn className='hover-grow cursor-pointer' />
+      <ShareBtn className='hover-grow cursor-pointer' onClick={copy} />
     </div>
   );
 };

--- a/src/components/ThreeDotIndicator/ThreeDotIndicator.stories.tsx
+++ b/src/components/ThreeDotIndicator/ThreeDotIndicator.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import { ThreeDotsIndicator } from './ThreeDotIndicator';
 
 const meta = {
-  title: 'Components/CircleIndicator',
+  title: 'Components/ThreeDotsIndicator',
   component: ThreeDotsIndicator,
   parameters: {
     layout: 'centered',

--- a/src/components/ThreeDotIndicator/ThreeDotIndicator.stories.tsx
+++ b/src/components/ThreeDotIndicator/ThreeDotIndicator.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { ThreeDotsIndicator } from './ThreeDotIndicator';
+
+const meta = {
+  title: 'Components/CircleIndicator',
+  component: ThreeDotsIndicator,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    dotColor: {
+      control: {
+        type: 'select',
+      },
+      options: ['default', 'primary'],
+      table: {
+        type: { summary: "'default' | 'primary'" },
+        defaultValue: { summary: "'default'" },
+      },
+    },
+    className: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+} satisfies Meta<typeof ThreeDotsIndicator>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    dotColor: 'default',
+  },
+};
+
+export const Primary: Story = {
+  args: {
+    dotColor: 'primary',
+  },
+};

--- a/src/components/ThreeDotIndicator/ThreeDotIndicator.tsx
+++ b/src/components/ThreeDotIndicator/ThreeDotIndicator.tsx
@@ -1,0 +1,65 @@
+import { cn } from '@/lib/cn';
+import { motion, HTMLMotionProps, Variants } from 'framer-motion'; // framer-motion으로 변경
+import { cva, VariantProps } from 'class-variance-authority';
+
+const circleIndicatorVariants = cva('h-2 w-2 rounded-full', {
+  variants: {
+    dotColor: {
+      default: 'bg-gray-400',
+      primary: 'bg-primary-orange-500',
+    },
+  },
+  defaultVariants: {
+    dotColor: 'default',
+  },
+});
+
+const containerVariants: Variants = {
+  initial: {
+    transition: {
+      staggerChildren: 0.2, // 자식 요소의 애니메이션 시작 간격
+    },
+  },
+  animate: {
+    transition: {
+      staggerChildren: 0.2,
+    },
+  },
+};
+
+const dotVariants: Variants = {
+  initial: {
+    y: 0,
+  },
+  animate: {
+    y: [0, -10, 0],
+    transition: {
+      repeat: Infinity,
+      repeatDelay: 0.4,
+      duration: 0.8,
+      ease: 'easeInOut',
+    },
+  },
+};
+
+export interface ThreeDotsIndicatorProps
+  extends HTMLMotionProps<'div'>,
+    VariantProps<typeof circleIndicatorVariants> {}
+
+const ThreeDotsIndicator = ({ className, dotColor, ...props }: ThreeDotsIndicatorProps) => {
+  return (
+    <motion.div
+      variants={containerVariants}
+      initial='initial'
+      animate='animate'
+      className={cn('flex-center gap-1', className)}
+      {...props}
+    >
+      <motion.span variants={dotVariants} className={cn(circleIndicatorVariants({ dotColor }))} />
+      <motion.span variants={dotVariants} className={cn(circleIndicatorVariants({ dotColor }))} />
+      <motion.span variants={dotVariants} className={cn(circleIndicatorVariants({ dotColor }))} />
+    </motion.div>
+  );
+};
+
+export { ThreeDotsIndicator, circleIndicatorVariants };

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+
+const useCopyToClipboard = () => {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      const urlToCopy = window.location.href;
+      await navigator.clipboard.writeText(urlToCopy);
+      setIsCopied(true);
+      alert('클립보드 복사 완료');
+    } catch (err) {
+      console.error('클립보드 복사 실패:', err);
+    }
+  };
+
+  useEffect(() => {
+    if (isCopied) {
+      const timer = setTimeout(() => {
+        setIsCopied(false);
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [isCopied]);
+
+  return [isCopied, copy];
+};
+
+export default useCopyToClipboard;


### PR DESCRIPTION
# 작업 내용
- 리뷰 리스트에 Suspense를 추가하여 리뷰 리스트에 대한 데이터 패칭이 레이아웃 Suspense에 캐치되지 않도록 수정했습니다.
- 이에 따라, ReviewList fetching 로직 또한, 하위 컴포넌트로 이동했습니다.
- 블러 이미지 `opacity`를 줄여달라는 요청이 있어서 줄였습니다. 색이 진한 이미지를 기준으로 전후 사진 첨부합니다.
<img width="870" height="582" alt="image" src="https://github.com/user-attachments/assets/5a6065c5-8c07-4df7-b812-b4c0c2d67b65" />
<img width="863" height="569" alt="image" src="https://github.com/user-attachments/assets/e617a703-6f46-4358-818b-9c8c2016cc4a" />

- 링크 공유 버튼 클릭 시, 클립보드에 링크가 복사되도록 구현했습니다.
- 댓글 삭제 버튼 클릭 시, 삭제 확인을 받도록 수정했습니다.

<img width="1062" height="236" alt="image" src="https://github.com/user-attachments/assets/92d0dd1a-a1ba-4b89-b6a7-feb6911a9d81" />


