### PR TITLE
[Fix] ImageInput 컴포넌트 - required 속성 추가(이미지 없어도 폼 제출 가능하도록 수정)

### DIFF
--- a/src/components/ImageInput/ImageInput.stories.tsx
+++ b/src/components/ImageInput/ImageInput.stories.tsx
@@ -142,3 +142,88 @@ export const WithReactHookFormMax5: Story = {
     },
   },
 };
+
+// React Hook Form과 함께 사용하는 스토리 - Required false
+const FormWrapperOptional = ({ maxImageCount }: { maxImageCount: number }) => {
+  const schema = z.object({
+    images: ImageInputSchema(maxImageCount, false),
+    title: z.string().min(1, '제목을 입력해주세요'),
+  });
+  type FormData = z.infer<typeof schema>;
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    mode: 'onChange',
+    defaultValues: {
+      images: getInitialImageList([]),
+      title: '',
+    },
+  });
+
+  const onSubmit = (data: FormData) => {
+    console.log('Form submitted:', data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className='space-y-4'>
+      <div>
+        <label htmlFor='title' className='mb-2 block text-sm font-medium'>
+          제품명
+        </label>
+        <input
+          id='title'
+          {...register('title')}
+          className='w-full rounded-lg border border-gray-300 p-2'
+          placeholder='제품명을 입력하세요'
+        />
+        {errors.title && <p className='mt-1 text-sm text-red-500'>{errors.title.message}</p>}
+      </div>
+
+      <div>
+        <label className='mb-2 block text-sm font-medium'>
+          이미지 (선택사항, {maxImageCount}개까지)
+        </label>
+        <Controller
+          name='images'
+          control={control}
+          render={({ field }) => (
+            <ImageInput
+              value={field.value}
+              onChange={field.onChange}
+              maxImageCount={maxImageCount}
+            />
+          )}
+        />
+      </div>
+
+      <button
+        type='submit'
+        disabled={!isValid}
+        className={`rounded-lg px-4 py-2 ${
+          isValid
+            ? 'bg-blue-500 text-white hover:bg-blue-600'
+            : 'cursor-not-allowed bg-gray-300 text-gray-500'
+        }`}
+      >
+        제출하기 {isValid ? '✓' : '✗'}
+      </button>
+    </form>
+  );
+};
+
+export const OptionalImageInput: Story = {
+  render: () => <FormWrapperOptional maxImageCount={3} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'required=false로 설정된 ImageInput 예시입니다. 이미지 선택 없이도 폼 제출이 가능합니다.',
+      },
+    },
+  },
+};

--- a/src/components/ImageInput/ImageInput.tsx
+++ b/src/components/ImageInput/ImageInput.tsx
@@ -7,13 +7,16 @@ import clsx from 'clsx';
 import { getUploadedImageUrlAPI } from '@/api/image/getUploadedImageUrlAPI';
 
 // ImageInput 전용 zod schema
-export const ImageInputSchema = (maxImageCount: number) => {
+export const ImageInputSchema = (maxImageCount: number, required: boolean = true) => {
   return z
     .record(
       z.string(),
       z.custom<File | null>((val) => val instanceof File || val === null),
     )
-    .refine((data) => Object.keys(data).length >= 1, '이미지를 1개 이상 선택해주세요')
+    .refine((data) => {
+      if (!required) return true;
+      return Object.keys(data).length >= 1;
+    }, '이미지를 1개 이상 선택해주세요')
     .refine(
       (data) => Object.keys(data).length <= maxImageCount,
       `최대 ${maxImageCount}개까지 선택 가능합니다`,


### PR DESCRIPTION
# 📜 작업 내용

## 💡 `ImageInputSchema`

required 속성을 추가하였습니다.

required를 false로 설정 시 이미지를 선택하지 않아도 폼 제출이 가능합니다.(기본값:  true)

스토리북 업데이트 하였으므로 참고해주세요!

```ts
// ImageInput 전용 zod schema
export const ImageInputSchema = (maxImageCount: number, required: boolean = true) => {
  return z
    .record(
      z.string(),
      z.custom<File | null>((val) => val instanceof File || val === null),
    )
    .refine((data) => {
      if (!required) return true;
      return Object.keys(data).length >= 1;
    }, '이미지를 1개 이상 선택해주세요')
    .refine(
      (data) => Object.keys(data).length <= maxImageCount,
      `최대 ${maxImageCount}개까지 선택 가능합니다`,
    );
};
```

## 💡 결과물
![Animation](https://github.com/user-attachments/assets/7a27c7c8-b1fa-4abf-9e30-c3041587f342)

