### PR TITLE
[Feat] 상품 상세 페이지 generateMetadata 적용 및 카카오톡 공유 기능 추가

### DIFF
--- a/src/app/product/[productId]/components/ProductShareBtns.tsx
+++ b/src/app/product/[productId]/components/ProductShareBtns.tsx
@@ -18,10 +18,34 @@ const ProductShareBtns = ({
 }: ProductShareBtnsProps) => {
   const [_isCopyed, copy] = useCopyToClipboard();
 
+  const shareKakaoTalk = () => {
+    const title =
+      document.querySelector('meta[property="og:title"]')?.getAttribute('content') || '';
+    const description =
+      document.querySelector('meta[property="og:description"]')?.getAttribute('content') || '';
+    const imageUrl =
+      document.querySelector('meta[property="og:image"]')?.getAttribute('content') || '';
+
+    if (window.Kakao) {
+      window.Kakao.Share.sendDefault({
+        objectType: 'feed',
+        content: {
+          title: title,
+          description: description,
+          imageUrl: imageUrl,
+          link: {
+            mobileWebUrl: window.location.href,
+            webUrl: window.location.href,
+          },
+        },
+      });
+    }
+  };
+
   return (
     <div className={cn('inline-flex-between-center mb-8 gap-3 md:mb-12', className)} {...props}>
       <HeartLikes productId={productId} favorite={isHeartFavorite} />
-      <KakaoShareBtn className='hover-grow cursor-pointer' />
+      <KakaoShareBtn className='hover-grow cursor-pointer' onClick={shareKakaoTalk} />
       <ShareBtn className='hover-grow cursor-pointer' onClick={copy} />
     </div>
   );

--- a/src/app/product/[productId]/page.tsx
+++ b/src/app/product/[productId]/page.tsx
@@ -4,6 +4,78 @@ import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query
 import { productKeys, reviewKeys } from '@/constant/queryKeys';
 import ProductDetailPage from './ProductDetailPage';
 import { getUserInfo } from '@/lib/getUserInfo';
+import { Metadata } from 'next';
+import { headers } from 'next/headers';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { productId: string };
+}): Promise<Metadata> {
+  const productId = Number(params.productId);
+
+  const headersList = headers();
+  const host = (await headersList).get('host') || 'new-project-final.link';
+  const currentUrl = `https://${host}/product/${productId}`;
+
+  try {
+    const productDetail = await getProductDetail(productId);
+
+    return {
+      title: `${productDetail.name} - 상품 상세`,
+      description: productDetail.description,
+      keywords: [
+        'mogazoa',
+        '모가조아',
+        productDetail.name,
+        '상품평가',
+        '상품통계',
+        '상품비교',
+        '상품리뷰',
+      ],
+      openGraph: {
+        title: `${productDetail.name} - 상품 상세 | mogazoa`,
+        description: productDetail.description,
+        siteName: 'mogazoa',
+        locale: 'ko_KR',
+        type: 'article',
+        publishedTime: productDetail.createdAt,
+        modifiedTime: productDetail.updatedAt,
+        section: productDetail.category.name,
+        url: currentUrl,
+        images: [
+          {
+            url: productDetail.image,
+            width: 200,
+            height: 200,
+            alt: `${productDetail.name} 상품 이미지`,
+          },
+        ],
+      },
+      robots: {
+        index: true,
+        follow: true,
+      },
+      alternates: {
+        canonical: currentUrl,
+      },
+    };
+  } catch (error) {
+    console.error('Failed to fetch product detail for metadata:', error);
+    return {
+      title: '상품 상세 페이지',
+      description: '상품 정보를 확인하세요.\n\nmogazoa에서 다양한 상품 리뷰와 정보를 확인하세요',
+      openGraph: {
+        title: `상품 상세`,
+        description: '상품 정보를 확인하세요.\n\nmogazoa에서 다양한 상품 리뷰와 정보를 확인하세요',
+        siteName: 'mogazoa',
+        locale: 'ko_KR',
+        type: 'article',
+        url: currentUrl,
+      },
+    };
+  }
+}
 
 const ProductDetailPageServer = async ({ params }: { params: Promise<{ productId: string }> }) => {
   const { productId: slug } = await params;

--- a/src/app/product/[productId]/page.tsx
+++ b/src/app/product/[productId]/page.tsx
@@ -7,19 +7,19 @@ import { getUserInfo } from '@/lib/getUserInfo';
 import { Metadata } from 'next';
 import { headers } from 'next/headers';
 
-export async function generateMetadata({
+export const generateMetadata = async ({
   params,
 }: {
   params: { productId: string };
-}): Promise<Metadata> {
-  const productId = Number(params.productId);
+}): Promise<Metadata> => {
+  const { productId: slug } = await params;
 
   const headersList = headers();
   const host = (await headersList).get('host') || 'new-project-final.link';
-  const currentUrl = `https://${host}/product/${productId}`;
+  const currentUrl = `https://${host}/product/${slug}`;
 
   try {
-    const productDetail = await getProductDetail(productId);
+    const productDetail = await getProductDetail(Number(slug));
 
     return {
       title: `${productDetail.name} - 상품 상세`,
@@ -75,7 +75,7 @@ export async function generateMetadata({
       },
     };
   }
-}
+};
 
 const ProductDetailPageServer = async ({ params }: { params: Promise<{ productId: string }> }) => {
   const { productId: slug } = await params;

--- a/src/app/product/[productId]/page.tsx
+++ b/src/app/product/[productId]/page.tsx
@@ -7,11 +7,13 @@ import { getUserInfo } from '@/lib/getUserInfo';
 import { Metadata } from 'next';
 import { headers } from 'next/headers';
 
-export const generateMetadata = async ({
-  params,
-}: {
-  params: { productId: string };
-}): Promise<Metadata> => {
+interface PageProps {
+  params: Promise<{
+    productId: string;
+  }>;
+}
+
+export const generateMetadata = async ({ params }: PageProps): Promise<Metadata> => {
   const { productId: slug } = await params;
 
   const headersList = headers();

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -48,9 +48,14 @@ interface KakaoAPI {
   ) => Promise<KakaoUserInfo | KakaoLogoutResponse | { id: number }>;
 }
 
+interface KakaoShare {
+  sendDefault: (options: KakaoLinkDefaultOptions) => void;
+}
+
 interface KakaoSDK {
   init: (appKey: string) => void;
   isInitialized: () => boolean;
   Auth: KakaoAuth;
   API: KakaoAPI;
+  Share: KakaoShare;
 }


### PR DESCRIPTION
# 작업 내용
- 상품 상세 페이지 내에서 동적 SEO를 적용하기 위해 `generateMetadata` 추가
- 카카오톡 공유 기능 추가

## 프리뷰
<img width="484" height="425" alt="image" src="https://github.com/user-attachments/assets/604e05d4-f540-4632-a917-9d2a18f33fbc" />
<img width="236" height="389" alt="image" src="https://github.com/user-attachments/assets/f57af915-2772-447d-9197-51637dc987b8" />

## 이슈
- 일부 상품의 경우 meta태그에 image정보가 있음에도 이미지가 생성되지 않는 이슈가 발생하고 있습니다.
- og 디버거 등을 활용하여 트러블슈팅하고 싶어서 우선 PR 적용 후, 배포 URL로 디버깅 예정입니다.