### PR TITLE
[Feat] 리뷰 & 상품 폼 다이얼로그 검증 추가 구현 및 리뷰 추가 버튼 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { Suspense } from 'react';
 import Header from '@/components/Header/Header';
 import { ToastRender } from 'cy-toast';
 import Loading from './loading/loading';
+import ProductAddButton from '@/components/ProductAddButton/ProductAddButton';
 
 const cafe24Supermagic = localFont({
   src: [
@@ -68,6 +69,7 @@ export default function RootLayout({
         <Providers>
           <Suspense fallback={<Loading />}>
             <Header />
+            <ProductAddButton className='fixed right-5 bottom-8 md:right-8 md:bottom-20 lg:right-[calc((100vw-980px)/2-72px))] lg:bottom-28' />
             {children}
           </Suspense>
           <GlobalDialog />

--- a/src/assets/icons/icon_plus.svg
+++ b/src/assets/icons/icon_plus.svg
@@ -1,3 +1,3 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M15.9993 6.66602V25.3327M6.66602 15.9993H25.3327" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/components/ProductAddButton/ProductAddButton.tsx
+++ b/src/components/ProductAddButton/ProductAddButton.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { HTMLAttributes, useEffect, useMemo, useState } from 'react';
+import { cn } from '@/lib/cn';
+import AddBtnIcon from '@/assets/icons/icon_plus.svg';
+import FloatingButton from '@/components/FloatingButton/FloatingButton';
+import useDialog from '@/hooks/useDialog';
+import { getUserInfo } from '@/lib/getUserInfo';
+import { usePathname } from 'next/navigation';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface ProductAddButtonProps extends HTMLAttributes<HTMLButtonElement> {}
+
+const ProductAddButton = ({ className, ...props }: ProductAddButtonProps) => {
+  const { open } = useDialog();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const pathname = usePathname();
+  const hiddenPaths = useMemo(() => ['/signin', '/signup'], []);
+  const isHidden = hiddenPaths.some((path) => pathname.startsWith(path));
+
+  const interactionStyles = 'hover:border-primary-orange-700 hover:border-2';
+
+  useEffect(() => {
+    if (hiddenPaths.includes(pathname)) return;
+
+    const fetchUserInfo = async () => {
+      try {
+        const userInfo = await getUserInfo();
+        setIsAuthenticated(userInfo.isAuthenticated);
+      } catch (error) {
+        console.error('Failed to fetch user info:', error);
+        setIsAuthenticated(false);
+      }
+    };
+
+    fetchUserInfo();
+  }, [hiddenPaths, pathname]);
+
+  return (
+    isAuthenticated &&
+    !isHidden && (
+      <FloatingButton
+        className={cn(
+          'bg-primary-orange-600 border-primary-orange-600 size-15',
+          interactionStyles,
+          className,
+        )}
+        onClick={() =>
+          open({
+            dialogName: 'product-form-dialog',
+            dialogProps: {
+              mode: 'create',
+            },
+            isBlockBackgroundClose: true,
+          })
+        }
+        {...props}
+      >
+        <AddBtnIcon className='size-8 fill-white' />
+      </FloatingButton>
+    )
+  );
+};
+
+export default ProductAddButton;


### PR DESCRIPTION
# 작업 내용
- 상품 폼 다이얼로그 검증 추가 구현
- 리뷰 폼 다이얼로그 검증 추가 구현
- 상품 추가 버튼 구현: 1. `/signin` `/signup` 페이지를 제외하고 2. 인증 상태에서만 렌더링 되게끔 로직을 구현했습니다.

## 이슈 사항
구현 안된 검증은 다음과 같습니다
- 상품 이름 입력창에서 blur될 때, 중복된 상품이 있다면 다음 에러 메시지를 보여주세요: “이미 등록된 상품입니다.” => `onError`가 실행되지 않아 서버 메세지를 못 받고 있음. 확인해보겠습니다.
- 이미지는 최대 3장까지 첨부할 수 있게 하고, 이미지 파일만 첨부할 수 있게 하세요. => 의도적으로 파일 탐색기에서 모든 파일 지정 후, 이미지가 아닌 파일을 첨부하면 첨부 자체는 됩니다. (요구사항에서는 아마 이렇게 넘겨지는걸 방지하라는 의미같은데,,,) request에서 막힐 것 같기는 합니다.
- 한 번에 여러 이미지를 추가할 수 있게 하세요. => 구현 안되어있음. `input` 태그에 `multiple` 속성을 주면 된다고는 합니다.
- 추가한 이미지를 눌러 이미지를 변경할 수 있게 하세요. => 구현 안되어있음