### PR TITLE
[Fix] ImageInput - 이미지가 아닌 파일 선택 시 첨부가 되지 않도록 수정

### DIFF
--- a/src/components/ImageInput/ImageInput.stories.tsx
+++ b/src/components/ImageInput/ImageInput.stories.tsx
@@ -31,6 +31,14 @@ export const Default: Story = {
   },
 };
 
+// 기본 ImageInput 스토리
+export const DefaultSingle: Story = {
+  args: {
+    value: {},
+    maxImageCount: 1,
+  },
+};
+
 // 기본값이 있는 ImageInput 스토리
 export const WithInitialImages: Story = {
   args: {

--- a/src/components/ImageInput/ImageInput.tsx
+++ b/src/components/ImageInput/ImageInput.tsx
@@ -84,6 +84,20 @@ const ImageInput = ({
         `최대 선택 가능한 갯수를 초과했습니다.\n선택 가능한 이미지 갯수: ${maxImageCount}개 \n총 선택된 이미지 갯수: ${totalFilesCount}개`,
       );
     } else {
+      for (const file of newFileArray) {
+        if (!file.type.startsWith('image/')) {
+          alert('이미지 파일만 업로드 가능합니다.');
+          e.target.value = ''; // input 초기화
+          return;
+        }
+        // 파일 크기 제한 (5MB)
+        if (file.size > 5 * 1024 * 1024) {
+          alert('파일 크기는 5MB 이하만 가능합니다.');
+          e.target.value = '';
+          return;
+        }
+      }
+
       const newImageList: Record<string, File> = {};
       newFileArray.forEach((file) => {
         const url = URL.createObjectURL(file);
@@ -139,7 +153,7 @@ const ImageInput = ({
         ref={fileInputRef}
         className='hidden'
         type='file'
-        multiple
+        multiple={maxImageCount === 1 ? false : true}
         accept='image/*'
         onChange={onInputChange}
       />


### PR DESCRIPTION
# 📜 작업 내용

- 이미지가 아닌 파일 선택 시 첨부가 되지 않도록 수정
- 파일 크기가 5mb 이상일 경우 첨부가 되지 않도록 수정
- maxLength가 1일 경우 multi 선택이 되지 않도록 수정

##  💡결과물
![Animation](https://github.com/user-attachments/assets/dc8869dd-612c-416b-b218-400bbecffdc4)
