### PR TITLE
[Fix] 다이얼로그 닫기 제어(ESC, 외부 클릭)가 isClosing에 의해 제어되지 않아 라우팅이 여러번 실행되던 문제 수정

### DIFF
--- a/src/components/Dialog/core/DialogComponents.tsx
+++ b/src/components/Dialog/core/DialogComponents.tsx
@@ -48,15 +48,19 @@ function DialogContent({
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
 }) {
-  const { close } = useDialog();
+  const { close, isClosing } = useDialog();
 
   return (
     <DialogPortal data-slot='dialog-portal'>
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot='dialog-content'
-        onPointerDownOutside={close}
-        onEscapeKeyDown={close}
+        onPointerDownOutside={() => {
+          if (!isClosing) close();
+        }}
+        onEscapeKeyDown={() => {
+          if (!isClosing) close();
+        }}
         aria-describedby={undefined}
         className={cn(
           'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 dialog-scrollable-content fixed top-[50%] left-[50%] z-50 grid max-h-[80vh] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',

--- a/src/hooks/useDialog.ts
+++ b/src/hooks/useDialog.ts
@@ -60,7 +60,9 @@ const useDialog = () => {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const open = ({ dialogName, dialogProps = undefined, isBlockBackgroundClose }: IOpen<any>) => {
-    router.push(`${pathname}#dialog=${dialogName}`, { scroll: false });
+    const cleanedPathname =
+      pathname.endsWith('/') && pathname.length > 1 ? pathname.slice(0, -1) : pathname;
+    router.push(`${cleanedPathname}#dialog=${dialogName}`, { scroll: false });
     openDialog({
       dialogName,
       dialogContent: DIALOG_COMPONENTS[dialogName](dialogProps),
@@ -72,17 +74,21 @@ const useDialog = () => {
    * 가장 최근에 열린 다이얼로그를 닫고 URL 해시를 변경
    */
   const close = () => {
-    router.back();
     closeDialog();
+    setTimeout(() => {
+      router.back();
+    }, 250);
   };
 
   /**
    * 열려있는 모든 다이얼로그를 닫고, 히스토리를 초기 상태로 되돌림
    */
   const closeAll = () => {
-    const { dialogs: latestDialogs } = useDialogStore.getState();
-    window.history.go(-latestDialogs.length);
     closeAllDialog();
+    setTimeout(() => {
+      const { dialogs: latestDialogs } = useDialogStore.getState();
+      window.history.go(-latestDialogs.length);
+    }, 250);
   };
 
   /**


### PR DESCRIPTION
# 작업내용
- 다이얼로그 닫기 제어(ESC, 외부 클릭)가 isClosing에 의해 제어되지 않아 라우팅이 여러번 실행되던 문제 수정
- 다이얼로그 닫기 버튼의 크기를 조정