### PR TITLE
[Refactor] axios 응답 인터셉터에 404 에러 시 notFound Redirect 구문 추가

### DIFF
--- a/src/lib/baseAPI.ts
+++ b/src/lib/baseAPI.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { redirect } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { getAccessToken } from './getAccessToken';
 
 export const baseAPI = axios.create({
@@ -37,7 +37,11 @@ baseAPI.interceptors.response.use(
       if (status === 401) {
         redirect('/signin?error=unauthorized');
       }
+      if (status === 404) {
+        notFound();
+      }
     }
+
     return Promise.reject(error);
   },
 );


### PR DESCRIPTION
# 📜 작업 내용

user/[userId]/page.tsx 에서 404 에러 시 notFound로 리다이렉트 하는 구문을 axios 응답 인터셉터로 이관하였습니다.


![Animation](https://github.com/user-attachments/assets/ffc53249-0b65-4539-bee6-2db2e8c302d6)
