### PR TITLE
[Fix] 로고 클릭 시 홈으로 이동

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -52,7 +52,7 @@ const HomeClient = () => {
     } else {
       return '';
     }
-  }, [category, searchKeyword, hasCategory, hasKeyword, getCategoryName]);
+  }, [category, searchKeyword]);
 
   return (
     <div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -70,9 +70,7 @@ const Header = () => {
   const handleLogoClick = () => {
     setInputValue('');
     setLocalSearchQuery('');
-
-    router.push('/');
-    router.refresh();
+    window.location.href = '/';
   };
 
   const handleSearchSubmit = (e: React.FormEvent<HTMLFormElement>) => {


### PR DESCRIPTION
## 📜 작업내용
검색어와 카테고리가 둘 다 있는 상태에서 로고 클릭 시 카테고리 남아있음, 이 상태에서 로고 클릭 시 홈으로 이동 이슈가 있어 수정했습니다.
카테고리 데이터가 계속 캐시에 남아있는 것 같아서 `router.push('/')` -> `window.location.href = '/'` 으로 수정했습니다.